### PR TITLE
Rework all import functions for GTFS Schedule and GTFS Realtime

### DIFF
--- a/backend/api/infobus.yml
+++ b/backend/api/infobus.yml
@@ -1,8 +1,8 @@
-openapi: '3.0.2'
+openapi: "3.0.2"
 info:
   title: Infobús API
   description: "Un servidor para recopilar datos desde diversas fuentes, incluyendo desde servidores en tiempo real con datos GTFS Realtime, y para distribución de información a servicios como páginas web, pantallas, aplicaciones, análisis de datos y otros.\n\n**Autores**\n\n Fabián Abarca Calderón, David Segura Cruz, Josué Vargas Céspedes \n\n *Escuela de Ingeniería Eléctrica, Universidad de Costa Rica*"
-  version: '1.0'
+  version: "1.0"
   contact:
     email: tropicalizacion@ucr.ac.cr
   x-logo:
@@ -10,12 +10,12 @@ info:
     altText: Logo bUCR
   license:
     name: MIT
-    url: 'https://opensource.org/license/mit/'
+    url: "https://opensource.org/license/mit/"
 servers:
   - url: https://infobus.bucr.digital/api
 
 paths:
-  /gtfs-providers:
+  /feed-publishers:
     get:
       summary: Proveedores de datos GTFS
       description: Información sobre los proveedores de datos GTFS del servicio de transporte público.
@@ -24,21 +24,21 @@ paths:
           name: code
           schema:
             type: string
-          description: 'Búsqueda de proveedor de datos GTFS por código identificador.'
+          description: "Búsqueda de proveedor de datos GTFS por código identificador."
         - in: query
           name: name
           schema:
             type: string
-          description: 'Búsqueda de proveedor de datos GTFS por nombre.'
+          description: "Búsqueda de proveedor de datos GTFS por nombre."
       tags:
         - Schedule
       responses:
-        '200':
+        "200":
           description: Solicitud procesada
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GTFSProvider'
+                $ref: "#/components/schemas/FeedPublisher"
   /agencies:
     get:
       summary: Agencias operadoras del servicio
@@ -48,21 +48,21 @@ paths:
           name: agency_id
           schema:
             type: string
-          description: 'Búsqueda de agencia operadora por identificador.'
+          description: "Búsqueda de agencia operadora por identificador."
         - in: query
           name: agency_name
           schema:
             type: string
-          description: 'Búsqueda de agencia operadora por nombre.'
+          description: "Búsqueda de agencia operadora por nombre."
       tags:
         - Schedule
       responses:
-        '200':
+        "200":
           description: Solicitud procesada
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Agency'
+                $ref: "#/components/schemas/Agency"
   /stops:
     get:
       summary: Datos sobre las paradas
@@ -70,53 +70,53 @@ paths:
       tags:
         - Schedule
       parameters:
-      - in: query
-        name: route_id
-        schema:
-          type: string
-        description: 'Búsqueda de paradas que pertenecen a una ruta particular.'
-      - in: query
-        name: location_type
-        schema:
-          type: integer
-          enum: [0, 1]
-        description: 'El tipo de parada, donde 0 es una parada o plataforma y 1 es una estación.'
-      - in: query
-        name: wheelchair_boarding
-        schema:
-          type: integer
-          enum: [0, 1, 2]
-        description: 'Indica si la parada permite el abordaje de sillas de ruedas, donde 0 es desconocido, 1 es accesible y 2 es no accesible.'
-      - in: query
-        name: located_within
-        schema:
-          type: string
-          example: 'POLYGON ((-85 9, -85 11, -83 11, -83 9, -85 9))'
-          format: WKT
-        description: 'Búsqueda de paradas dentro de un región, especificada como un polígono en formato WKT.'
-      - in: query
-        name: close_to
-        schema:
-          type: string
-          example: 'POINT (-84 9)'
-          format: WKT
-        description: 'Búsqueda de paradas cercanas a una ubicación, especificada como un punto en formato WKT.'
-      - in: query
-        name: distance
-        schema:
-          type: integer
-          example: 400
-          default: 800
-        description: 'Distancia en metros para la búsqueda de paradas cercanas a un punto.'
+        - in: query
+          name: route_id
+          schema:
+            type: string
+          description: "Búsqueda de paradas que pertenecen a una ruta particular."
+        - in: query
+          name: location_type
+          schema:
+            type: integer
+            enum: [0, 1]
+          description: "El tipo de parada, donde 0 es una parada o plataforma y 1 es una estación."
+        - in: query
+          name: wheelchair_boarding
+          schema:
+            type: integer
+            enum: [0, 1, 2]
+          description: "Indica si la parada permite el abordaje de sillas de ruedas, donde 0 es desconocido, 1 es accesible y 2 es no accesible."
+        - in: query
+          name: located_within
+          schema:
+            type: string
+            example: "POLYGON ((-85 9, -85 11, -83 11, -83 9, -85 9))"
+            format: WKT
+          description: "Búsqueda de paradas dentro de un región, especificada como un polígono en formato WKT."
+        - in: query
+          name: close_to
+          schema:
+            type: string
+            example: "POINT (-84 9)"
+            format: WKT
+          description: "Búsqueda de paradas cercanas a una ubicación, especificada como un punto en formato WKT."
+        - in: query
+          name: distance
+          schema:
+            type: integer
+            example: 400
+            default: 800
+          description: "Distancia en metros para la búsqueda de paradas cercanas a un punto."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Stops'
+                  $ref: "#/components/schemas/Stops"
   /shapes:
     get:
       summary: Trayectorias de las rutas
@@ -126,19 +126,19 @@ paths:
           name: shape_id
           schema:
             type: string
-            example: 'desde_educacion'
-          description: 'Búsqueda de trayectorias que pertenecen a una trayectoria particular.'
+            example: "desde_educacion"
+          description: "Búsqueda de trayectorias que pertenecen a una trayectoria particular."
       tags:
         - Schedule
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Shapes'
+                  $ref: "#/components/schemas/Shapes"
   /calendar:
     get:
       summary: Días de operación de las rutas
@@ -150,17 +150,17 @@ paths:
           name: service_id
           schema:
             type: string
-            example: 'entresemana'
-          description: 'Búsqueda de días de operación en un servicio particular.'
+            example: "entresemana"
+          description: "Búsqueda de días de operación en un servicio particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Calendar'
+                  $ref: "#/components/schemas/Calendar"
   /calendar-dates:
     get:
       summary: Excepciones de operación de las rutas
@@ -172,17 +172,17 @@ paths:
           name: service_id
           schema:
             type: string
-            example: 'entresemana'
-          description: 'Búsqueda de excepciones de operación en un servicio particular.'
+            example: "entresemana"
+          description: "Búsqueda de excepciones de operación en un servicio particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/CalendarDates'
+                  $ref: "#/components/schemas/CalendarDates"
   /routes:
     get:
       summary: Datos de las rutas
@@ -194,24 +194,24 @@ paths:
           name: route_id
           schema:
             type: string
-            example: 'bUCR-L1'
-          description: 'Búsqueda por identificador de ruta.'
+            example: "bUCR-L1"
+          description: "Búsqueda por identificador de ruta."
         - in: query
           name: route_type
           schema:
             type: integer
             enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-          description: 'Tipo de ruta, según GTFS, donde 3 es autobús.'
+          description: "Tipo de ruta, según GTFS, donde 3 es autobús."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Routes'
-  /trips:  
+                  $ref: "#/components/schemas/Routes"
+  /trips:
     get:
       summary: Datos de los viajes
       description: Datos sobre los viajes, como la hora de inicio, la fecha de inicio y la relación con el horario.
@@ -222,41 +222,41 @@ paths:
           name: trip_id
           schema:
             type: string
-            example: 'NROD7888'
-          description: 'Búsqueda por identificador de viaje.'
+            example: "NROD7888"
+          description: "Búsqueda por identificador de viaje."
         - in: query
           name: route_id
           schema:
             type: string
-            example: 'bUCR-L1'
-          description: 'Búsqueda de viajes que pertenecen a una ruta particular.'
+            example: "bUCR-L1"
+          description: "Búsqueda de viajes que pertenecen a una ruta particular."
         - in: query
           name: direction_id
           schema:
             type: integer
             enum: [0, 1]
-          description: 'Búsqueda de viajes en una dirección particular.'
+          description: "Búsqueda de viajes en una dirección particular."
         - in: query
           name: service_id
           schema:
             type: string
-            example: 'entresemana'
-          description: 'Búsqueda de viajes en días de operación particulares.'
+            example: "entresemana"
+          description: "Búsqueda de viajes en días de operación particulares."
         - in: query
           name: shape_id
           schema:
             type: string
-            example: 'desde_educacion'
-          description: 'Búsqueda de viajes en una trayectoria particular.'
+            example: "desde_educacion"
+          description: "Búsqueda de viajes en una trayectoria particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Trips'
+                  $ref: "#/components/schemas/Trips"
   /stop-times:
     get:
       summary: Horarios de llegada a las paradas
@@ -268,23 +268,23 @@ paths:
           name: trip_id
           schema:
             type: string
-            example: 'JFH367'
-          description: 'Búsqueda de horarios de paradas en un viaje particular.'
+            example: "JFH367"
+          description: "Búsqueda de horarios de paradas en un viaje particular."
         - in: query
           name: stop_id
           schema:
             type: string
-            example: 'bUCR-0-03'
-          description: 'Búsqueda de horarios de paradas en una parada particular.'
+            example: "bUCR-0-03"
+          description: "Búsqueda de horarios de paradas en una parada particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/StopTimes'
+                  $ref: "#/components/schemas/StopTimes"
   /frequencies:
     get:
       summary: Frecuencias de los viajes
@@ -296,17 +296,17 @@ paths:
           name: trip_id
           schema:
             type: string
-            example: 'JFH367'
-          description: 'Búsqueda de frecuencias de viajes en un viaje particular.'
+            example: "JFH367"
+          description: "Búsqueda de frecuencias de viajes en un viaje particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Frequencies'
+                  $ref: "#/components/schemas/Frequencies"
   /feed-info:
     get:
       summary: Información del feed
@@ -318,17 +318,17 @@ paths:
           name: feed_publisher_name
           schema:
             type: string
-            example: 'bUCR'
-          description: 'Búsqueda de información del feed por nombre del proveedor.'
+            example: "bUCR"
+          description: "Búsqueda de información del feed por nombre del proveedor."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/FeedInfo'
+                  $ref: "#/components/schemas/FeedInfo"
   /route-stops:
     get:
       summary: Paradas de las rutas
@@ -340,17 +340,17 @@ paths:
           name: route_id
           schema:
             type: string
-            example: 'bUCR-L1'
-          description: 'Búsqueda de paradas en una ruta particular.'
+            example: "bUCR-L1"
+          description: "Búsqueda de paradas en una ruta particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RouteStops'
+                  $ref: "#/components/schemas/RouteStops"
   /geoshapes:
     get:
       summary: Trayectorias de las rutas en formato GeoJSON
@@ -362,17 +362,17 @@ paths:
           name: shape_id
           schema:
             type: string
-            example: 'desde_educacion'
-          description: 'Búsqueda de una trayectoria particular.'
+            example: "desde_educacion"
+          description: "Búsqueda de una trayectoria particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/geo+json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/GeoShapes'
+                  $ref: "#/components/schemas/GeoShapes"
   /trip-times:
     get:
       summary: Horarios de salida los viajes
@@ -384,17 +384,17 @@ paths:
           name: trip_id
           schema:
             type: string
-            example: 'JFH367'
-          description: 'Búsqueda de horarios de un viaje particular.'
+            example: "JFH367"
+          description: "Búsqueda de horarios de un viaje particular."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TripTimes'     
+                  $ref: "#/components/schemas/TripTimes"
   /next-trips:
     get:
       summary: Próximos viajes
@@ -406,28 +406,28 @@ paths:
           name: stop_id
           schema:
             type: string
-            example: 'bUCR-0-03'
-          description: 'Búsqueda de próximos viajes en una parada particular.'
+            example: "bUCR-0-03"
+          description: "Búsqueda de próximos viajes en una parada particular."
           required: true
         - in: query
           name: route_id
           schema:
             type: string
-          description: 'Búsqueda de próximos viajes filtrada por parada y por ruta.'
+          description: "Búsqueda de próximos viajes filtrada por parada y por ruta."
         - in: query
           name: timestamp
           schema:
             type: string
-            example: '2024-07-31T16:12:25'
-          description: 'Fecha y hora de referencia en el futuro para buscar próximos viajes a partir de ese momento. Será asumida la zona horaria de la agencia. Parámetro opcional, por defecto es el momento actual.'
+            example: "2024-07-31T16:12:25"
+          description: "Fecha y hora de referencia en el futuro para buscar próximos viajes a partir de ese momento. Será asumida la zona horaria de la agencia. Parámetro opcional, por defecto es el momento actual."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NextTrips'
-        '400':
+                $ref: "#/components/schemas/NextTrips"
+        "400":
           description: Bad Request - Es necesario especificar el stop_id como parámetro de la solicitud.
   /next-stops:
     get:
@@ -440,31 +440,31 @@ paths:
           name: trip_id
           schema:
             type: string
-            example: 'JFH367'
-          description: 'Búsqueda de próximas paradas en un viaje particular.'
+            example: "JFH367"
+          description: "Búsqueda de próximas paradas en un viaje particular."
           required: true
         - in: query
           name: start_date
           schema:
             type: string
-            example: '2024-07-31'
-          description: 'Fecha de salida del viaje.'
+            example: "2024-07-31"
+          description: "Fecha de salida del viaje."
           required: true
         - in: query
           name: start_time
           schema:
             type: string
-            example: '16:12:25'
-          description: 'Hora de salida del viaje.'
+            example: "16:12:25"
+          description: "Hora de salida del viaje."
           required: true
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NextStops'
-        '400':
+                $ref: "#/components/schemas/NextStops"
+        "400":
           description: Bad Request - Es necesario especificar todos los parámetros de la solicitud, trip_id, start_date y start_time.
   /vehicle-positions:
     get:
@@ -472,73 +472,81 @@ paths:
       description: Datos sobre las posiciones de los vehículos, como la ubicación, la velocidad y la dirección.
       tags:
         - Realtime
-      parameters: 
+      parameters:
         - in: query
           name: vehicle_vehicle_id
           schema:
             type: string
-          description: 'Búsqueda de posiciones de vehículos por identificador.'
+          description: "Búsqueda de posiciones de vehículos por identificador."
         - in: query
           name: vehicle_trip_route_id
           schema:
             type: string
-          description: 'Búsqueda de posiciones de vehículos por ruta.'
+          description: "Búsqueda de posiciones de vehículos por ruta."
         - in: query
           name: vehicle_trip_trip_id
           schema:
             type: string
-          description: 'Búsqueda de posiciones de vehículos por viaje.'
+          description: "Búsqueda de posiciones de vehículos por viaje."
         - in: query
           name: vehicle_trip_schedule_relationship
           schema:
             type: string
-            enum: ['SCHEDULED', 'ADDED', 'UNSCHEDULED', 'CANCELED', 'DUPLICATED', 'DELETED']
-          description: 'Búsqueda de posiciones de vehículos por relación con el horario.'
+            enum:
+              [
+                "SCHEDULED",
+                "ADDED",
+                "UNSCHEDULED",
+                "CANCELED",
+                "DUPLICATED",
+                "DELETED",
+              ]
+          description: "Búsqueda de posiciones de vehículos por relación con el horario."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/VehiclePositions'
+                  $ref: "#/components/schemas/VehiclePositions"
   /trip-updates:
     get:
       summary: Actualizaciones de los viajes
       description: Obtiene las horas de llegada y salida de las paradas en tiempo real.
       tags:
         - Realtime
-      parameters: 
+      parameters:
         - in: query
           name: trip_trip_id
           schema:
             type: string
-          description: 'Búsqueda de actualizaciones de viajes por identificador.'
+          description: "Búsqueda de actualizaciones de viajes por identificador."
         - in: query
           name: trip_route_id
           schema:
             type: string
-          description: 'Búsqueda de actualizaciones de viajes por ruta.'
+          description: "Búsqueda de actualizaciones de viajes por ruta."
         - in: query
           name: trip_start_time
           schema:
             type: string
-          description: 'Búsqueda de actualizaciones de viajes por hora de salida.'
+          description: "Búsqueda de actualizaciones de viajes por hora de salida."
         - in: query
           name: vehicle_id
           schema:
             type: string
-          description: 'Búsqueda de actualizaciones de viajes por identificador de vehículo.'
+          description: "Búsqueda de actualizaciones de viajes por identificador de vehículo."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TripUpdates'
+                  $ref: "#/components/schemas/TripUpdates"
   /service-alerts:
     get:
       summary: Alertas del servicio
@@ -550,36 +558,36 @@ paths:
           name: alert_id
           schema:
             type: string
-          description: 'Búsqueda de alertas por identificador de servicio.'
+          description: "Búsqueda de alertas por identificador de servicio."
         - in: query
           name: route_id
           schema:
             type: string
-          description: 'Búsqueda de alertas por ruta.'
+          description: "Búsqueda de alertas por ruta."
         - in: query
           name: trip_id
           schema:
             type: string
-          description: 'Búsqueda de alertas por viaje.'
+          description: "Búsqueda de alertas por viaje."
         - in: query
           name: service_start_time
           schema:
             type: string
-          description: 'Búsqueda de alertas por hora de inicio.'
+          description: "Búsqueda de alertas por hora de inicio."
         - in: query
           name: service_date
           schema:
             type: string
-          description: 'Búsqueda de alertas por fecha de inicio.'
+          description: "Búsqueda de alertas por fecha de inicio."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServiceAlerts'
+                  $ref: "#/components/schemas/ServiceAlerts"
   /weather:
     get:
       summary: Datos meteorológicos
@@ -591,21 +599,21 @@ paths:
           name: weather_location
           schema:
             type: string
-          description: 'Búsqueda de datos meteorológicos por ubicación.'
+          description: "Búsqueda de datos meteorológicos por ubicación."
         - in: query
           name: weather_condition
           schema:
             type: string
-          description: 'Búsqueda de datos meteorológicos por condición.'
+          description: "Búsqueda de datos meteorológicos por condición."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Weather'
+                  $ref: "#/components/schemas/Weather"
   /social:
     get:
       summary: Redes sociales
@@ -617,26 +625,26 @@ paths:
           name: social_media
           schema:
             type: string
-          description: 'Búsqueda de redes sociales por nombre.'
+          description: "Búsqueda de redes sociales por nombre."
         - in: query
           name: social_location
           schema:
             type: string
-          description: 'Búsqueda de redes sociales por ubicación.'
+          description: "Búsqueda de redes sociales por ubicación."
         - in: query
           name: social_content
           schema:
             type: string
-          description: 'Búsqueda de redes sociales por contenido.'
+          description: "Búsqueda de redes sociales por contenido."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Social'
+                  $ref: "#/components/schemas/Social"
   /user-reports:
     get:
       summary: Reportes de personas usuarias
@@ -644,21 +652,21 @@ paths:
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserReports'
+                  $ref: "#/components/schemas/UserReports"
     post:
       summary: Reportes de personas usuarias
       description: Publica reportes de personas usuarias sobre el servicio.
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
   /user-data:
     get:
@@ -667,21 +675,21 @@ paths:
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserData'
+                  $ref: "#/components/schemas/UserData"
     post:
       summary: Datos de personas usuarias
       description: Publica datos de personas usuarias del servicio.
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
   /wide-alerts:
     get:
@@ -690,7 +698,7 @@ paths:
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
     post:
       summary: Alertas generales
@@ -698,14 +706,14 @@ paths:
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WideAlerts'
+                  $ref: "#/components/schemas/WideAlerts"
   /info-service:
     get:
       summary: Servicios de información
@@ -715,65 +723,74 @@ paths:
           name: type
           schema:
             type: string
-            enum: ['website', 'screens', 'app', 'analysis', 'chatbot', 'social', 'other']
-          description: 'Búsqueda por tipo de servicios de información.'
+            enum:
+              [
+                "website",
+                "screens",
+                "app",
+                "analysis",
+                "chatbot",
+                "social",
+                "other",
+              ]
+          description: "Búsqueda por tipo de servicios de información."
         - in: query
           name: name
           schema:
             type: string
-          description: 'Búsqueda por nombre de servicios de información.'
+          description: "Búsqueda por nombre de servicios de información."
       tags:
         - External
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/InfoService'
+                  $ref: "#/components/schemas/InfoService"
 
 components:
   schemas:
-    GTFSProvider:
+    FeedPublisher:
       type: object
       properties:
         code:
           description: Identificador del proveedor de datos
           type: string
-          example: 'MBTA'
+          example: "MBTA"
         name:
           description: Nombre del proveedor de datos
           type: string
-          example: 'Massachusetts Bay Transportation Authority'
+          example: "Massachusetts Bay Transportation Authority"
         description:
           description: Descrippción del proveedor de datos
           type: string
-          example: 'La agencia de transporte público de Boston.'
+          example: "La agencia de transporte público de Boston."
         website:
           description: Sitio web del proveedor de datos
           type: string
-          example: 'https://www.mbta.com/'
+          example: "https://www.mbta.com/"
         schedule_url:
           description: URL del GTFS Schedule
           type: string
-          example: 'https://cdn.mbta.com/MBTA_GTFS.zip'
+          example: "https://cdn.mbta.com/MBTA_GTFS.zip"
         trip_updates_url:
           description: URL de actualizaciones de viajes
           type: string
-          example: 'https://cdn.mbta.com/realtime/TripUpdates.pb'
+          example: "https://cdn.mbta.com/realtime/TripUpdates.pb"
         vehicle_positions_url:
           description: URL de posiciones de vehículos
           type: string
-          example: 'https://cdn.mbta.com/realtime/VehiclePositions.pb'
+          example: "https://cdn.mbta.com/realtime/VehiclePositions.pb"
         service_alerts_url:
           description: URL de alertas de servicio
           type: string
-          example: 'https://cdn.mbta.com/realtime/Alerts.pb'
+          example: "https://cdn.mbta.com/realtime/Alerts.pb"
         timezone:
           description: Zona horaria del proveedor de datos
           type: string
-          example: 'America/New_York'
+          example: "America/New_York"
         is_active:
           description: Estado de activación del proveedor de datos
           type: boolean
@@ -784,50 +801,50 @@ components:
         agency_id:
           description: Identificador de la agencia según GTFS Schedule
           type: string
-          example: 'bUCR'
+          example: "bUCR"
         agency_name:
           description: Nombre de la agencia
           type: string
-          example: 'bUCR'
+          example: "bUCR"
         agency_url:
           description: URL de la agencia
           type: string
-          example: 'https://bucr.digital'
+          example: "https://bucr.digital"
         agency_timezone:
           description: Zona horaria de la agencia
           type: string
-          example: 'America/Costa_Rica'
+          example: "America/Costa_Rica"
         agency_lang:
           description: Lenguaje de la agencia
           type: string
-          example: 'es'
+          example: "es"
         agency_phone:
           description: Teléfono de la agencia
           type: string
-          example: '+506 2511-0000'
+          example: "+506 2511-0000"
         agency_fare_url:
           description: URL de tarifas de la agencia
           type: string
-          example: 'https://bucr.digital/tarifas'
+          example: "https://bucr.digital/tarifas"
         agency_email:
           description: Correo electrónico de la agencia
           type: string
-          example: 'bus@ucr.ac.cr'
+          example: "bus@ucr.ac.cr"
     Stops:
       type: object
       properties:
         stop_id:
           description: Identificador único de la parada
           type: string
-          example: 'bUCR-0-03'
+          example: "bUCR-0-03"
         stop_name:
           description: Nombre de la parada
           type: string
-          example: 'Facultad de Ingeniería'
+          example: "Facultad de Ingeniería"
         stop_desc:
           description: Descripción de la parada
           type: string
-          example: 'Facultad de Ingeniería en la Ciudad de la Investigación de la Universidad de Costa Rica'
+          example: "Facultad de Ingeniería en la Ciudad de la Investigación de la Universidad de Costa Rica"
         stop_lat:
           description: Latitud de la parada
           type: number
@@ -841,7 +858,7 @@ components:
         stop_url:
           description: URL de la parada
           type: string
-          example: 'https://bucr.digital/paradas/bUCR-0-03'
+          example: "https://bucr.digital/paradas/bUCR-0-03"
         location_type:
           description: Tipo de ubicación
           type: integer
@@ -858,7 +875,7 @@ components:
         shape_id:
           description: Identificador de la trayectoria
           type: string
-          example: 'desde_educacion'
+          example: "desde_educacion"
         shape_pt_lat:
           description: Latitud de la forma
           type: number
@@ -884,7 +901,7 @@ components:
         service_id:
           description: Identificador del servicio
           type: string
-          example: 'entresemana'
+          example: "entresemana"
         monday:
           description: Operación los lunes
           type: integer
@@ -923,22 +940,22 @@ components:
         start_date:
           description: Fecha de inicio de operación
           type: string
-          example: '2024-05-03'
+          example: "2024-05-03"
         end_date:
           description: Fecha de fin de operación
           type: string
-          example: '2024-12-31'
+          example: "2024-12-31"
     CalendarDates:
       type: object
       properties:
         service_id:
           description: Identificador del servicio
           type: string
-          example: 'entresemana'
+          example: "entresemana"
         date:
           description: Fecha de excepción
           type: string
-          example: '2024-08-15'
+          example: "2024-08-15"
         exception_type:
           description: Tipo de excepción
           type: integer
@@ -947,26 +964,26 @@ components:
         holiday_name:
           description: Nombre del feriado
           type: string
-          example: 'Día de la Madre'
+          example: "Día de la Madre"
     Routes:
       type: object
       properties:
         route_id:
           description: Identificador de la ruta
           type: string
-          example: 'bUCR-L1'
+          example: "bUCR-L1"
         route_short_name:
           description: Nombre corto de la ruta
           type: string
-          example: 'L1'
+          example: "L1"
         route_long_name:
           description: Nombre largo de la ruta
           type: string
-          example: 'Línea 1'
+          example: "Línea 1"
         route_desc:
           description: Descripción de la ruta
           type: string
-          example: 'Línea 1 de buses de la Universidad de Costa Rica'
+          example: "Línea 1 de buses de la Universidad de Costa Rica"
         route_type:
           description: Tipo de ruta
           type: integer
@@ -975,57 +992,57 @@ components:
         route_url:
           description: URL de la ruta
           type: string
-          example: 'https://bucr.digital/rutas/L1'
+          example: "https://bucr.digital/rutas/L1"
     Trips:
       type: object
       properties:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         route_id:
           description: Identificador de la ruta según GTFS Schedule
           type: string
-          example: 'bUCR-L1'
+          example: "bUCR-L1"
         direction_id:
           description: Identificador de la dirección del viaje según GTFS Schedule
           type: integer
           example: 0
-      #  start_time:
-      #    description: Hora de inicio del viaje
-      #    type: string
-      #    example: '07:15:00'
-      #  start_date:
-      #    description: Fecha de inicio del viaje
-      #    type: string
-      #    example: '2024-05-03'
-      #  schedule_relationship:
-      #    description: Relación con el horario
-      #    type: string
-      #    enum: ['SCHEDULED', 'ADDED', 'UNSCHEDULED', 'CANCELED', 'DUPLICATED', 'DELETED']
+        #  start_time:
+        #    description: Hora de inicio del viaje
+        #    type: string
+        #    example: '07:15:00'
+        #  start_date:
+        #    description: Fecha de inicio del viaje
+        #    type: string
+        #    example: '2024-05-03'
+        #  schedule_relationship:
+        #    description: Relación con el horario
+        #    type: string
+        #    enum: ['SCHEDULED', 'ADDED', 'UNSCHEDULED', 'CANCELED', 'DUPLICATED', 'DELETED']
         trip_headsign:
           description: Letrero del viaje
           type: string
-          example: 'Facultad de Ingeniería'
+          example: "Facultad de Ingeniería"
     StopTimes:
       type: object
       properties:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         arrival_time:
           description: Hora de llegada a la parada
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         departure_time:
           description: Hora de salida de la parada
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         stop_id:
           description: Identificador de la parada según GTFS Schedule
           type: string
-          example: 'bUCR-0-03'
+          example: "bUCR-0-03"
         stop_sequence:
           description: Secuencia de la parada
           type: integer
@@ -1033,7 +1050,7 @@ components:
         stop_headsign:
           description: Letrero de la parada
           type: string
-          example: 'Facultad de Ingeniería'
+          example: "Facultad de Ingeniería"
         pickup_type:
           description: Tipo de abordaje
           type: integer
@@ -1055,15 +1072,15 @@ components:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         start_time:
           description: Hora de inicio de la frecuencia
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         end_time:
           description: Hora de fin de la frecuencia
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         headway_secs:
           description: Intervalo de tiempo entre viajes
           type: integer
@@ -1074,34 +1091,34 @@ components:
         feed_publisher_name:
           description: Nombre del proveedor de datos
           type: string
-          example: 'bUCR'
+          example: "bUCR"
         feed_publisher_url:
           description: URL del proveedor de datos
           type: string
-          example: 'https://bucr.digital'
+          example: "https://bucr.digital"
         feed_lang:
           description: Lenguaje del feed
           type: string
-          example: 'es'
+          example: "es"
         feed_start_date:
           description: Fecha de inicio del feed
           type: string
-          example: '2024-05-03'
+          example: "2024-05-03"
         feed_end_date:
           description: Fecha de fin del feed
           type: string
-          example: '2024-12-31'
+          example: "2024-12-31"
         feed_version:
           description: Versión del feed
           type: string
-          example: '1.0.0'
+          example: "1.0.0"
     RouteStops:
       type: object
       properties:
         route_id:
           description: Identificador de la ruta
           type: string
-          example: 'bUCR-L1'
+          example: "bUCR-L1"
         stop_sequence:
           description: Secuencia de la parada
           type: integer
@@ -1109,11 +1126,11 @@ components:
         stop_id:
           description: Identificador de la parada
           type: string
-          example: 'bUCR-0-03'
+          example: "bUCR-0-03"
         stop_name:
           description: Nombre de la parada
           type: string
-          example: 'Facultad de Ingeniería'
+          example: "Facultad de Ingeniería"
         stop_lat:
           description: Latitud de la parada
           type: number
@@ -1127,7 +1144,7 @@ components:
         stop_url:
           description: URL de la parada
           type: string
-          example: 'https://bucr.digital/paradas/bUCR-0-03'
+          example: "https://bucr.digital/paradas/bUCR-0-03"
         location_type:
           description: Tipo de ubicación
           type: integer
@@ -1156,7 +1173,7 @@ components:
           properties:
             type:
               type: string
-              enum: [LineString] 
+              enum: [LineString]
             coordinates:
               type: array
               items:
@@ -1164,7 +1181,7 @@ components:
                 items:
                   type: number
                   format: float
-                minItems: 2  
+                minItems: 2
                 maxItems: 3
               minItems: 2
               example: [[-84.051, 9.937], [-84.052, 9.938]]
@@ -1174,7 +1191,7 @@ components:
             shape_id:
               description: Identificador de la trayectoria
               type: string
-              example: 'desde_educacion'
+              example: "desde_educacion"
             has_altitude:
               description: Indica si la trayectoria tiene datos de altitud
               type: boolean
@@ -1185,15 +1202,15 @@ components:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         start_time:
           description: Hora de inicio del viaje
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         end_time:
           description: Hora de fin del viaje
           type: string
-          example: '07:15:00'
+          example: "07:15:00"
         duration:
           description: Duración del viaje
           type: integer
@@ -1204,11 +1221,11 @@ components:
         stop_id:
           description: Identificador de la parada según GTFS Schedule
           type: string
-          example: 'bUCR-0-03'
+          example: "bUCR-0-03"
         timestamp:
           description: Hora de referencia para buscar próximos viajes
           type: string
-          example: '2024-07-31T16:12:25-06:00'
+          example: "2024-07-31T16:12:25-06:00"
         next_arrivals:
           type: array
           items:
@@ -1217,36 +1234,42 @@ components:
               trip_id:
                 description: Identificador del viaje según GTFS Schedule
                 type: string
-                example: 'JFH367'
+                example: "JFH367"
               route_id:
                 description: Identificador de la ruta según GTFS Schedule
                 type: string
-                example: 'bUCR-L1'
+                example: "bUCR-L1"
               route_short_name:
                 description: Nombre corto de la ruta
                 type: string
-                example: 'L1'
+                example: "L1"
               route_long_name:
                 description: Nombre largo de la ruta
                 type: string
-                example: 'Línea 1'
+                example: "Línea 1"
               trip_headsign:
                 description: Destino del viaje
                 type: string
-                example: 'Facultad de Ingeniería'
+                example: "Facultad de Ingeniería"
               wheelchair_accessible:
                 description: Accesibilidad para sillas de ruedas
                 type: string
-                enum: ['NO_VALUE', 'UNKNOWN', 'WHEELCHAIR_ACCESSIBLE', 'WHEELCHAIR_INACCESSIBLE']
-                example: 'WHEELCHAIR_ACCESSIBLE'
+                enum:
+                  [
+                    "NO_VALUE",
+                    "UNKNOWN",
+                    "WHEELCHAIR_ACCESSIBLE",
+                    "WHEELCHAIR_INACCESSIBLE",
+                  ]
+                example: "WHEELCHAIR_ACCESSIBLE"
               arrival_time:
                 description: Hora de llegada a la parada
                 type: string
-                example: '07:15:00'
+                example: "07:15:00"
               departure_time:
                 description: Hora de salida de la parada
                 type: string
-                example: '07:15:00'
+                example: "07:15:00"
               in_progress:
                 description: Indica si el viaje está en progreso
                 type: boolean
@@ -1269,27 +1292,38 @@ components:
                   current_status:
                     description: Estado actual del vehículo en relación con la parada
                     type: string
-                    enum: ['INCOMING_AT', 'STOPPED_AT', 'IN_TRANSIT_TO']
-                    example: 'STOPPED_AT'
+                    enum: ["INCOMING_AT", "STOPPED_AT", "IN_TRANSIT_TO"]
+                    example: "STOPPED_AT"
                   occupancy_status:
                     description: Estado de ocupación del vehículo
                     type: string
-                    enum: ['EMPTY', 'MANY_SEATS_AVAILABLE', 'FEW_SEATS_AVAILABLE', 'STANDING_ROOM_ONLY', 'CRUSHED_STANDING_ROOM_ONLY', 'FULL', 'NOT_ACCEPTING_PASSENGERS', 'NO_DATA_AVAILABLE', 'NOT_BOARDABLE']
+                    enum:
+                      [
+                        "EMPTY",
+                        "MANY_SEATS_AVAILABLE",
+                        "FEW_SEATS_AVAILABLE",
+                        "STANDING_ROOM_ONLY",
+                        "CRUSHED_STANDING_ROOM_ONLY",
+                        "FULL",
+                        "NOT_ACCEPTING_PASSENGERS",
+                        "NO_DATA_AVAILABLE",
+                        "NOT_BOARDABLE",
+                      ]
     NextStops:
       type: object
       properties:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         start_date:
           description: Fecha de inicio del viaje
           type: string
-          example: '2024-07-31'
+          example: "2024-07-31"
         start_time:
           description: Hora de inicio del viaje
           type: string
-          example: '16:12:25'
+          example: "16:12:25"
         next_stop_sequence:
           type: array
           items:
@@ -1302,11 +1336,11 @@ components:
               stop_id:
                 description: Identificador de la parada según GTFS Schedule
                 type: string
-                example: 'bUCR-0-03'
+                example: "bUCR-0-03"
               stop_name:
                 description: Nombre de la parada
                 type: string
-                example: 'Facultad de Ingeniería'
+                example: "Facultad de Ingeniería"
               stop_lat:
                 description: Latitud de la parada
                 type: number
@@ -1320,29 +1354,29 @@ components:
               arrival:
                 description: Día y hora de llegada a la parada en formato ISO 8601
                 type: string
-                example: '2024-07-31T16:12:25-06:00'
+                example: "2024-07-31T16:12:25-06:00"
               departure:
                 description: Día y hora de salida de la parada en formato ISO 8601
                 type: string
-                example: '2024-07-31T16:12:25-06:00'
+                example: "2024-07-31T16:12:25-06:00"
     VehiclePositions:
       type: object
       properties:
         vehicle:
-          $ref: '#/components/schemas/Vehicle'
+          $ref: "#/components/schemas/Vehicle"
         schedule:
-          $ref: '#/components/schemas/Schedule'
+          $ref: "#/components/schemas/Schedule"
         loading:
-          $ref: '#/components/schemas/Loading'
+          $ref: "#/components/schemas/Loading"
         equipment:
-          $ref: '#/components/schemas/Equipment'
+          $ref: "#/components/schemas/Equipment"
     TripUpdates:
       type: object
       properties:
         trip_id:
           description: Identificador del viaje según GTFS Schedule
           type: string
-          example: 'JFH367'
+          example: "JFH367"
         stop_time_update:
           type: array
           items:
@@ -1351,58 +1385,72 @@ components:
               stop_id:
                 description: Identificador de la parada según GTFS Schedule
                 type: string
-                example: 'bUCR-0-03'
+                example: "bUCR-0-03"
               arrival:
                 description: Hora de llegada a la parada
                 type: string
-                example: '07:15:00'
+                example: "07:15:00"
               departure:
                 description: Hora de salida de la parada
                 type: string
-                example: '07:15:00'
+                example: "07:15:00"
               schedule_relationship:
                 description: Relación con el horario
                 type: string
-                enum: ['SCHEDULED', 'ADDED', 'UNSCHEDULED', 'CANCELED', 'DUPLICATED', 'DELETED']
+                enum:
+                  [
+                    "SCHEDULED",
+                    "ADDED",
+                    "UNSCHEDULED",
+                    "CANCELED",
+                    "DUPLICATED",
+                    "DELETED",
+                  ]
     ServiceAlerts:
       type: object
       properties:
         alert_id:
           description: Identificador de la alerta
           type: string
-          example: 'bUCR-001'
+          example: "bUCR-001"
         alert_header:
           description: Encabezado de la alerta
           type: string
-          example: 'Cierre de vías'
+          example: "Cierre de vías"
         alert_description:
           description: Descripción de la alerta
           type: string
-          example: 'Cierre de vías en la Ciudad de la Investigación'
+          example: "Cierre de vías en la Ciudad de la Investigación"
         alert_url:
           description: URL de la alerta
           type: string
-          example: 'https://bucr.digital/alertas/bUCR-001'
+          example: "https://bucr.digital/alertas/bUCR-001"
     Vehicle:
       type: object
       properties:
         id:
           description: Identificador del vehículo
           type: string
-          example: 'MEYS-8236'
+          example: "MEYS-8236"
         label:
           description: Etiqueta del vehículo
           type: string
-          example: 'MEYS-8236'
+          example: "MEYS-8236"
         license_plate:
           description: Placa del vehículo
           type: string
-          example: 'SJB 9876'
+          example: "SJB 9876"
         wheelchair_accessible:
           description: Accesibilidad para sillas de ruedas
           type: string
-          enum: ['NO_VALUE', 'UNKNOWN', 'WHEELCHAIR_ACCESSIBLE', 'WHEELCHAIR_INACCESSIBLE']
-          example: 'WHEELCHAIR_ACCESSIBLE'
+          enum:
+            [
+              "NO_VALUE",
+              "UNKNOWN",
+              "WHEELCHAIR_ACCESSIBLE",
+              "WHEELCHAIR_INACCESSIBLE",
+            ]
+          example: "WHEELCHAIR_ACCESSIBLE"
     Schedule:
       type: object
       properties:
@@ -1413,25 +1461,43 @@ components:
         stop_id:
           description: Identificador de la parada
           type: string
-          example: 'bUCR-0-03'
+          example: "bUCR-0-03"
         current_status:
           description: Estado actual del vehículo
           type: string
-          enum: ['INCOMING_AT', 'STOPPED_AT', 'IN_TRANSIT_TO']
-          example: 'STOPPED_AT'
+          enum: ["INCOMING_AT", "STOPPED_AT", "IN_TRANSIT_TO"]
+          example: "STOPPED_AT"
         congestion_level:
           description: Nivel de congestión vehicular en la vía
           type: string
-          enum: ['UNKNOWN_CONGESTION_LEVEL', 'RUNNING_SMOOTHLY', 'STOP_AND_GO', 'CONGESTION', 'SEVERE_CONGESTION']
-          example: 'SEVERE_CONGESTION'
+          enum:
+            [
+              "UNKNOWN_CONGESTION_LEVEL",
+              "RUNNING_SMOOTHLY",
+              "STOP_AND_GO",
+              "CONGESTION",
+              "SEVERE_CONGESTION",
+            ]
+          example: "SEVERE_CONGESTION"
     Loading:
       type: object
       properties:
         occupancy_status:
           description: Estado de la ocupación de la parada
           type: string
-          enum: ['EMPTY', 'MANY_SEATS_AVAILABLE', 'FEW_SEATS_AVAILABLE', 'STANDING_ROOM_ONLY', 'CRUSHED_STANDING_ROOM_ONLY', 'FULL', 'NOT_ACCEPTING_PASSENGERS', 'NO_DATA_AVAILABLE', 'NOT_BOARDABLE']
-          example: 'CRUSHED_STANDING_ROOM_ONLY'
+          enum:
+            [
+              "EMPTY",
+              "MANY_SEATS_AVAILABLE",
+              "FEW_SEATS_AVAILABLE",
+              "STANDING_ROOM_ONLY",
+              "CRUSHED_STANDING_ROOM_ONLY",
+              "FULL",
+              "NOT_ACCEPTING_PASSENGERS",
+              "NO_DATA_AVAILABLE",
+              "NOT_BOARDABLE",
+            ]
+          example: "CRUSHED_STANDING_ROOM_ONLY"
         occupancy_percentage:
           description: Porcentaje de ocupación del vehículo según capacidad de carga
           type: integer
@@ -1442,23 +1508,23 @@ components:
         serial_number:
           description: Número de serie del equipo
           type: string
-          example: 'MEYS-8236'
+          example: "MEYS-8236"
         brand:
           description: Marca del equipo
           type: string
-          example: 'MEYS'
+          example: "MEYS"
         model:
           description: Modelo del equipo
           type: string
-          example: 'MEYS-8236'
+          example: "MEYS-8236"
         software_version:
           description: Versión del software del equipo
           type: string
-          example: '1.0.0'
+          example: "1.0.0"
         owner:
           description: Propietario del equipo
           type: string
-          example: 'bUCR'
+          example: "bUCR"
     Weather:
       type: object
       properties:
@@ -1508,88 +1574,97 @@ components:
         facebook:
           description: URL de la página de Facebook
           type: string
-          example: 'https://www.facebook.com/bUCR'
+          example: "https://www.facebook.com/bUCR"
         twitter:
           description: URL de la cuenta de Twitter
           type: string
-          example: 'https://twitter.com/bUCR'
+          example: "https://twitter.com/bUCR"
         instagram:
           description: URL de la cuenta de Instagram
           type: string
-          example: 'https://www.instagram.com/bUCR'
+          example: "https://www.instagram.com/bUCR"
         youtube:
           description: URL del canal de YouTube
           type: string
-          example: 'https://www.youtube.com/bUCR'
+          example: "https://www.youtube.com/bUCR"
     UserReports:
       type: object
       properties:
         user_id:
           description: Identificador de la persona usuaria
           type: string
-          example: '123456'
+          example: "123456"
         user_name:
           description: Nombre de la persona usuaria
           type: string
-          example: 'Juan Pérez'
+          example: "Juan Pérez"
         user_email:
           description: Correo electrónico de la persona usuaria
           type: string
-          example: 'ejemplo@ejemplo.com'
+          example: "ejemplo@ejemplo.com"
     UserData:
       type: object
       properties:
         user_id:
           description: Identificador de la persona usuaria
           type: string
-          example: '123456'
+          example: "123456"
         user_name:
           description: Nombre de la persona usuaria
           type: string
-          example: 'Juan Pérez'
+          example: "Juan Pérez"
         user_email:
           description: Correo electrónico de la persona usuaria
           type: string
-          example: 'persona@ejemplo.com'
+          example: "persona@ejemplo.com"
     WideAlerts:
       type: object
       properties:
         alert_id:
           description: Identificador de la alerta
           type: string
-          example: 'bUCR-001'
+          example: "bUCR-001"
         alert_header:
           description: Encabezado de la alerta
           type: string
-          example: 'Cierre de vías'
+          example: "Cierre de vías"
         alert_description:
           description: Descripción de la alerta
           type: string
-          example: 'Cierre de vías en la Ciudad de la Investigación'
+          example: "Cierre de vías en la Ciudad de la Investigación"
         alert_url:
           description: URL de la alerta
           type: string
-          example: 'https://bucr.digital/alertas/bUCR-001'
+          example: "https://bucr.digital/alertas/bUCR-001"
     InfoService:
       type: object
       properties:
         name:
           description: Identificador del servicio
           type: string
-          example: 'Infobús Pantallas'
+          example: "Infobús Pantallas"
         description:
           description: Descripción del servicio
           type: string
-          example: 'Servicio de pantallas informativas en la Universidad de Costa Rica'
+          example: "Servicio de pantallas informativas en la Universidad de Costa Rica"
         type:
           description: Tipo de servicio de información
           type: string
-          enum: ['website', 'screens', 'app', 'analysis', 'chatbot', 'social', 'other']
-          example: 'screens'
+          enum:
+            [
+              "website",
+              "screens",
+              "app",
+              "analysis",
+              "chatbot",
+              "social",
+              "other",
+            ]
+          example: "screens"
         provider:
           description: Proveedor del servicio
           type: string
-          example: 'Infobús S.A.'
+          example: "Infobús S.A."
 
 tags:
   - name: Schedule

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -4,12 +4,12 @@ from alerts.models import *
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer, GeometryField
 
-# from gtfs.models import GTFSProvider, Route, Trip, StopTime, Stop, FeedInfo, Calendar, CalendarDate, Shape, GeoShape, FareAttribute, FareRule, ServiceAlert, Weather, Social, FeedMessage, TripUpdate, StopTimeUpdate, VehiclePosition, Agency
+# from gtfs.models import FeedPublisher, Route, Trip, StopTime, Stop, FeedInfo, Calendar, CalendarDate, Shape, GeoShape, FareAttribute, FareRule, ServiceAlert, Weather, Social, FeedMessage, TripUpdate, StopTimeUpdate, VehiclePosition, Agency
 
 
-class GTFSProviderSerializer(serializers.HyperlinkedModelSerializer):
+class FeedPublisherSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
-        model = GTFSProvider
+        model = FeedPublisher
         fields = "__all__"
 
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -6,7 +6,7 @@ from . import views
 
 router = routers.DefaultRouter()
 router.register(r"info-services", views.InfoServiceViewSet)
-router.register(r"gtfs-providers", views.GTFSProviderViewSet)
+router.register(r"feed-publishers", views.FeedPublisherViewSet)
 router.register(r"agencies", views.AgencyViewSet)
 router.register(r"stops", views.StopViewSet)
 router.register(r"geo-stops", views.GeoStopViewSet, basename="geo-stop")

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.http import FileResponse
 from engine.models import InfoService
 from feed.models import (
-    GTFSProvider,
+    FeedPublisher,
     Agency,
     Stop,
     Route,
@@ -22,7 +22,7 @@ from django.conf import settings
 
 from .serializers import *
 
-# from .serializers import InfoServiceSerializer, GTFSProviderSerializer, RouteSerializer, TripSerializer
+# from .serializers import InfoServiceSerializer, FeedPublisherSerializer, RouteSerializer, TripSerializer
 
 
 class FilterMixin:
@@ -37,13 +37,13 @@ class FilterMixin:
         return queryset.filter(**filter_args)
 
 
-class GTFSProviderViewSet(viewsets.ModelViewSet):
+class FeedPublisherViewSet(viewsets.ModelViewSet):
     """
     Proveedores de datos GTFS.
     """
 
-    queryset = GTFSProvider.objects.all()
-    serializer_class = GTFSProviderSerializer
+    queryset = FeedPublisher.objects.all()
+    serializer_class = FeedPublisherSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["code", "name"]
     # permission_classes = [permissions.IsAuthenticated]

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -3,17 +3,90 @@ from celery import shared_task
 import logging
 from datetime import datetime, timedelta
 import pytz
+from django.db import transaction
 import zipfile
 import io
-import json
 import pandas as pd
 import requests
 from google.transit import gtfs_realtime_pb2 as gtfs_rt
-from google.protobuf import json_format
-from asgiref.sync import async_to_sync
-from channels.layers import get_channel_layer
+from feed.models import (
+    FeedPublisher,
+    Feed,
+    FeedMessage,
+    VehiclePosition,
+    TripUpdate,
+    StopTimeUpdate,
+    Agency,
+    Stop,
+    Shape,
+    Calendar,
+    CalendarDate,
+    Route,
+    Trip,
+    StopTime,
+    FeedInfo,
+)
 
-from gtfs.models import *
+logging.basicConfig(
+    format="%(levelname)s: %(message)s",
+    encoding="utf-8",
+    level=logging.INFO,
+)
+
+
+def gtfs_time(value):
+    """Convert GTFS HH:MM:SS strings (including >24h) to timedelta."""
+    if not value:
+        return None
+    if isinstance(value, timedelta):
+        return value
+
+    try:
+        hours, minutes, seconds = map(int, str(value).split(":"))
+    except (ValueError, AttributeError):
+        return None
+
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+def gtfs_date(value):
+    """Convert GTFS YYYYMMDD strings to date objects for Django DateField."""
+    if not value:
+        return None
+    if hasattr(value, "year") and hasattr(value, "month") and hasattr(value, "day"):
+        return value
+
+    try:
+        return datetime.strptime(str(value), "%Y%m%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def gtfs_timestamp(value, timezone=pytz.UTC):
+    """Convert GTFS unix timestamp values to timezone-aware datetime."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value
+
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
+def normalize_gtfs_value(value):
+    """Convert null-like CSV values to None before model instantiation."""
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned.lower() in {"", "nan", "none", "null"}:
+            return None
+        return cleaned
+    return value
 
 
 @shared_task
@@ -23,326 +96,337 @@ def hello_world():
 
 @shared_task
 def get_schedule():
-
-    # Logging configuration
-    logging.basicConfig(
-        format="%(levelname)s: %(message)s",
-        encoding="utf-8",
-        level=logging.INFO,
-    )
-
-    # GTFS information
-    company = "MBTA"
-    schedule_url = "https://cdn.mbta.com/MBTA_GTFS.zip"
-
-    logging.info(
-        f"GTFS Schedule updating session\n{company}\n{datetime.now()}\nData source: {schedule_url}"
-    )
-
-    # Check if the feed has been updated
-    last_feed_tag = {"value": None}
-    try:
-        last_feed_tag["value"] = (
-            Feed.objects.all().order_by("-retrieved_at").first().http_etag
+    feed_publishers = FeedPublisher.objects.filter(is_active=True)
+    if not feed_publishers.exists():
+        logging.warning(
+            "No active feed publishers found in the database. Please add at least one active publisher to fetch schedules."
         )
-    except:
-        logging.info("No records found in the table 'feeds'.")
+        return "No active feed publishers found. Schedule update skipped."
 
-    # Get the feed's ETag to compare with the last one
-    schedule_check = requests.head(schedule_url)
-    feed_tag = schedule_check.headers["ETag"]
+    for feed_publisher in feed_publishers:
+        logging.info(
+            f"Active feed publisher found: {feed_publisher.name} ({feed_publisher.code}). Proceeding with schedule update."
+        )
+        schedule_url = feed_publisher.schedule_url
 
-    if not feed_tag == last_feed_tag["value"]:
-        logging.info(f"Importing new GTFS Schedule feed detected: {feed_tag}")
-
-        # Request feed
-        schedule_response = requests.get(schedule_url)
-        schedule_zip = zipfile.ZipFile(io.BytesIO(schedule_response.content))
-
-        last_modified = schedule_check.headers["Last-Modified"]
-        last_modified = datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
-        last_modified = last_modified.replace(tzinfo=pytz.UTC)
-        feed_id = f"{company}-{int(last_modified.timestamp())}"
-
-        # Save feed record to database with the Feed model
-        feed = Feed.objects.create(
-            feed_id=feed_id,
-            http_etag=feed_tag,
-            http_last_modified=last_modified,
+        logging.info(
+            f"\n------------\nGTFS Schedule updating session\n{feed_publisher.name}\n{datetime.now()}\nData source: {schedule_url}\n------------"
         )
 
-        tables = {
-            "agency": "Agency",
-            "stops": "Stop",
-            "shapes": "Shape",
-            "calendar": "Calendar",
-            "calendar_dates": "CalendarDate",
-            "routes": "Route",
-            "trips": "Trip",
-            "stop_times": "StopTime",
-            "feed_info": "FeedInfo",
-        }  # They must be loaded in this order
+        # Check if the remote feed has been updated
+        current_feed = (
+            Feed.objects.filter(feed_publisher=feed_publisher, is_current=True)
+            .order_by("-retrieved_at")
+            .first()
+        )
+        current_feed_tag = None
+        if current_feed:
+            current_feed_tag = current_feed.http_etag
+        else:
+            logging.info(
+                "No feed records found in the table 'feeds'. New acquisition needed."
+            )
 
-        # Import and save tables
-        for table_name in tables.keys():
-            file = f"{table_name}.txt"
-            if file in schedule_zip.namelist():
-                model = eval(f"{tables[table_name]}")
-                fields = [field.name for field in model._meta.fields]
-                table = pd.read_csv(
-                    schedule_zip.open(file),
-                    dtype=str,
-                    keep_default_na=False,
-                    na_values="",
-                )
-                table = table[[col for col in fields if col in table.columns]]
-                table["feed"] = feed
-                objects = [model(**row) for row in table.to_dict(orient="records")]
-                model.objects.bulk_create(objects)
-                logging.info(f"{file} imported successfully")
+        # Get the feed's ETag to compare with the last one
+        feed_check = requests.head(schedule_url)
+        feed_tag = feed_check.headers["ETag"]
 
-    return "Fetching Schedule"
+        if not feed_tag == current_feed_tag:
+            logging.info(f"Importing new detected GTFS Schedule feed: {feed_tag}")
+
+            # Request feed
+            schedule_response = requests.get(schedule_url)
+            schedule_zip = zipfile.ZipFile(io.BytesIO(schedule_response.content))
+
+            last_modified = feed_check.headers["Last-Modified"]
+            last_modified = datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
+            last_modified = last_modified.replace(tzinfo=pytz.UTC)
+            feed_id = f"{feed_publisher.code} ({last_modified.strftime('%Y-%m-%d %H:%M:%S %Z')})"
+
+            # Save new feed record to database with the Feed model
+            if current_feed:
+                current_feed.is_current = False
+                current_feed.save(update_fields=["is_current"])
+            feed = Feed.objects.create(
+                feed_id=feed_id,
+                http_etag=feed_tag,
+                http_last_modified=last_modified,
+                is_current=True,
+                feed_publisher=feed_publisher,
+            )
+
+            tables = {
+                "agency": Agency,
+                "stops": Stop,
+                "shapes": Shape,
+                "calendar": Calendar,
+                "calendar_dates": CalendarDate,
+                "routes": Route,
+                "trips": Trip,
+                "stop_times": StopTime,
+                "feed_info": FeedInfo,
+            }  # They must be loaded in this order
+
+            # Import and save tables
+            for table_name in tables.keys():
+                file = f"{table_name}.txt"
+                if file in schedule_zip.namelist():
+                    model = tables[table_name]
+                    fields = [field.name for field in model._meta.fields]
+                    table = pd.read_csv(
+                        schedule_zip.open(file),
+                        dtype=str,
+                        keep_default_na=False,
+                        na_values="",
+                    )
+                    table = table[[col for col in fields if col in table.columns]]
+                    table["feed"] = feed
+                    for row in table.to_dict(orient="records"):
+                        instance = model(
+                            **{
+                                key: normalize_gtfs_value(value)
+                                for key, value in row.items()
+                            }
+                        )
+                        instance.save()
+                    logging.info(f"{file} imported successfully")
+
+            logging.info("Schedule updated successfully")
+        else:
+            logging.info("No new feed detected. Schedule is up to date.")
+
+    return "Schedule update completed. Check logs for details."
 
 
 @shared_task
 def get_vehicle_positions():
-    providers = GTFSProvider.objects.filter(is_active=True)
-    saved_data = False
-    for provider in providers:
+    publishers = FeedPublisher.objects.filter(is_active=True)
+    for publisher in publishers:
         vehicle_positions = gtfs_rt.FeedMessage()
         try:
-            vehicle_positions_response = requests.get(provider.vehicle_positions_url)
-            print(f"Fetching vehicle positions from {provider.vehicle_positions_url}")
-        except:
+            vehicle_positions_response = requests.get(publisher.vehicle_positions_url)
+            print(f"Fetching vehicle positions from {publisher.vehicle_positions_url}")
+            vehicle_positions.ParseFromString(vehicle_positions_response.content)
+        except requests.RequestException as e:
             print(
-                f"Error fetching vehicle positions from {provider.vehicle_positions_url}"
+                f"Error fetching vehicle positions from {publisher.vehicle_positions_url}: {e}"
             )
             continue
-        vehicle_positions.ParseFromString(vehicle_positions_response.content)
 
-        # Save feed message to database
+        # Save FeedMessage object
         feed_message = FeedMessage(
-            feed_message_id=f"{provider.code}-vehicle-{vehicle_positions.header.timestamp}",
-            provider=provider,
+            feed_message_id=f"{publisher.code}-vehicle-{vehicle_positions.header.timestamp}",
+            publisher=publisher,
             entity_type="vehicle",
-            timestamp=datetime.fromtimestamp(
-                int(vehicle_positions.header.timestamp),
-                tz=pytz.timezone(provider.timezone),
+            timestamp=gtfs_timestamp(
+                vehicle_positions.header.timestamp,
+                timezone=pytz.timezone(publisher.timezone),
             ),
             incrementality=vehicle_positions.header.incrementality,
             gtfs_realtime_version=vehicle_positions.header.gtfs_realtime_version,
         )
-
         feed_message.save()
 
-        vehicle_positions_json = json_format.MessageToJson(
-            vehicle_positions, preserving_proto_field_name=True
-        )
-        vehicle_positions_json = json.loads(vehicle_positions_json)
-        if "entity" not in vehicle_positions_json:
-            print("No vehicle positions found")
-            continue
-        vehicle_positions_df = pd.json_normalize(
-            vehicle_positions_json["entity"], sep="_"
-        )
-        vehicle_positions_df.rename(columns={"id": "entity_id"}, inplace=True)
-        vehicle_positions_df["feed_message"] = feed_message
-        # Drop unnecessary columns
-        try:
-            vehicle_positions_df.drop(
-                columns=["vehicle_multi_carriage_details"],
-                inplace=True,
+        # Save VehiclePosition objects
+        entities = vehicle_positions.entity
+        vehicle_positions_to_create = []
+        for entity in entities:
+            v = entity.vehicle
+            vehicle_positions_to_create.append(
+                VehiclePosition(
+                    entity_id=entity.id,
+                    feed_message=feed_message,
+                    trip_trip_id=v.trip.trip_id if v.trip.HasField("trip_id") else None,
+                    trip_route_id=v.trip.route_id
+                    if v.trip.HasField("route_id")
+                    else None,
+                    trip_direction_id=v.trip.direction_id
+                    if v.trip.HasField("direction_id")
+                    else None,
+                    trip_start_time=gtfs_time(v.trip.start_time)
+                    if v.trip.HasField("start_time")
+                    else None,
+                    trip_start_date=gtfs_date(v.trip.start_date)
+                    if v.trip.HasField("start_date")
+                    else None,
+                    trip_schedule_relationship=v.trip.schedule_relationship
+                    if v.trip.HasField("schedule_relationship")
+                    else None,
+                    vehicle_id=v.vehicle.id if v.vehicle.HasField("id") else None,
+                    vehicle_label=v.vehicle.label
+                    if v.vehicle.HasField("label")
+                    else None,
+                    vehicle_license_plate=v.vehicle.license_plate
+                    if v.vehicle.HasField("license_plate")
+                    else None,
+                    position_latitude=v.position.latitude
+                    if v.position.HasField("latitude")
+                    else None,
+                    position_longitude=v.position.longitude
+                    if v.position.HasField("longitude")
+                    else None,
+                    position_bearing=v.position.bearing
+                    if v.position.HasField("bearing")
+                    else None,
+                    position_odometer=v.position.odometer
+                    if v.position.HasField("odometer")
+                    else None,
+                    position_speed=v.position.speed
+                    if v.position.HasField("speed")
+                    else None,
+                    current_stop_sequence=v.current_stop_sequence
+                    if v.current_stop_sequence is not None
+                    else None,
+                    stop_id=v.stop_id if v.stop_id is not None else None,
+                    current_status=v.current_status
+                    if v.current_status is not None
+                    else None,
+                    timestamp=gtfs_timestamp(v.timestamp)
+                    if v.HasField("timestamp")
+                    else None,
+                    congestion_level=v.congestion_level
+                    if v.HasField("congestion_level")
+                    else None,
+                    occupancy_status=v.occupancy_status
+                    if v.HasField("occupancy_status")
+                    else None,
+                    occupancy_percentage=v.occupancy_percentage
+                    if v.HasField("occupancy_percentage")
+                    else None,
+                )
             )
-        except:
-            pass
-        # Fix entity timestamp
-        vehicle_positions_df["vehicle_timestamp"] = pd.to_datetime(
-            vehicle_positions_df["vehicle_timestamp"].astype(int), unit="s", utc=True
-        )
-        # Fix trip start date
-        vehicle_positions_df["vehicle_trip_start_date"] = pd.to_datetime(
-            vehicle_positions_df["vehicle_trip_start_date"], format="%Y%m%d"
-        )
-        vehicle_positions_df["vehicle_trip_start_date"].fillna(
-            datetime.now().date(), inplace=True
-        )
-        # Fix trip start time
-        vehicle_positions_df["vehicle_trip_start_time"] = pd.to_timedelta(
-            vehicle_positions_df["vehicle_trip_start_time"]
-        )
-        vehicle_positions_df["vehicle_trip_start_time"].fillna(
-            timedelta(hours=0, minutes=0, seconds=0), inplace=True
-        )
-        # Fix trip direction
-        vehicle_positions_df["vehicle_trip_direction_id"].fillna(-1, inplace=True)
-        # Fix current stop sequence
-        vehicle_positions_df["vehicle_current_stop_sequence"].fillna(-1, inplace=True)
-        # Create vehicle position point
-        vehicle_positions_df["vehicle_position_point"] = vehicle_positions_df.apply(
-            lambda x: (
-                f"POINT ({x.vehicle_position_longitude} {x.vehicle_position_latitude})"
-            ),
-            axis=1,
-        )
-        # Save to database
-        objects = [
-            VehiclePosition(**row)
-            for row in vehicle_positions_df.to_dict(orient="records")
-        ]
-        VehiclePosition.objects.bulk_create(objects)
-        saved_data = saved_data or True
 
-    # Send status update to WebSocket
-    message = {}
-    message["last_update"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    message["number_providers"] = len(providers)
-    channel_layer = get_channel_layer()
-    async_to_sync(channel_layer.group_send)(
-        "status",
-        {
-            "type": "status_message",
-            "message": message,
-        },
-    )
+        if vehicle_positions_to_create:
+            VehiclePosition.objects.bulk_create(
+                vehicle_positions_to_create,
+                batch_size=2000,
+            )
 
-    if saved_data:
-        return "VehiclePositions saved to database"
-    else:
-        return "No VehiclePositions found"
+    return "Task completed: VehiclePositions saved to database"
 
 
 @shared_task
 def get_trip_updates():
-    providers = GTFSProvider.objects.filter(is_active=True)
-    for provider in providers:
+    publishers = FeedPublisher.objects.filter(is_active=True)
+    for publisher in publishers:
+        trip_updates = gtfs_rt.FeedMessage()
         try:
-            trip_updates_response = requests.get(provider.trip_updates_url, timeout=10)
-            trip_updates_response.raise_for_status()
+            trip_updates_response = requests.get(publisher.trip_updates_url, timeout=10)
+            print(f"Fetching trip updates from {publisher.trip_updates_url}")
+            trip_updates.ParseFromString(trip_updates_response.content)
         except requests.RequestException as e:
             print(
-                f"Error fetching trip updates from {provider.trip_updates_url}: {str(e)}"
+                f"Error fetching trip updates from {publisher.trip_updates_url}: {str(e)}"
             )
             continue
 
-        # Parse FeedMessage object from Protobuf
-        trip_updates = gtfs_rt.FeedMessage()
-        trip_updates.ParseFromString(trip_updates_response.content)
-
-        # Build FeedMessage object
+        # Save FeedMessage object
         feed_message = FeedMessage(
-            feed_message_id=f"{provider.code}-trip_updates-{trip_updates.header.timestamp}",
-            provider=provider,
+            feed_message_id=f"{publisher.code}-trip_updates-{trip_updates.header.timestamp}",
+            publisher=publisher,
             entity_type="trip_update",
-            timestamp=datetime.fromtimestamp(
-                int(trip_updates.header.timestamp),
-                tz=pytz.timezone(provider.timezone),
+            timestamp=gtfs_timestamp(
+                trip_updates.header.timestamp,
+                timezone=pytz.timezone(publisher.timezone),
             ),
             incrementality=trip_updates.header.incrementality,
             gtfs_realtime_version=trip_updates.header.gtfs_realtime_version,
         )
-        # Save FeedMessage object
         feed_message.save()
 
-        # Build TripUpdate DataFrame
-        trip_updates_json = json_format.MessageToJson(
-            trip_updates, preserving_proto_field_name=True
-        )
-        trip_updates_json = json.loads(trip_updates_json)
-        trip_updates_df = pd.json_normalize(trip_updates_json["entity"], sep="_")
-        trip_updates_df.rename(columns={"id": "entity_id"}, inplace=True)
-        trip_updates_df["feed_message"] = feed_message
+        # Save TripUpdate entities and their related StopTimeUpdate objects
+        entities = trip_updates.entity
+        trip_updates_to_create = []
+        stop_time_updates_by_trip_index = []
 
-        # Fix entity timestamp
-        trip_updates_df["trip_update_timestamp"].fillna(
-            datetime.now().timestamp(), inplace=True
-        )
-        trip_updates_df["trip_update_timestamp"] = pd.to_datetime(
-            trip_updates_df["trip_update_timestamp"].astype(int), unit="s", utc=True
-        )
-        # Fix trip start date
-        trip_updates_df["trip_update_trip_start_date"] = pd.to_datetime(
-            trip_updates_df["trip_update_trip_start_date"], format="%Y%m%d"
-        )
-        trip_updates_df["trip_update_trip_start_date"].fillna(
-            datetime.now().date(), inplace=True
-        )
-        # Fix trip start time
-        trip_updates_df["trip_update_trip_start_time"] = pd.to_timedelta(
-            trip_updates_df["trip_update_trip_start_time"]
-        )
-        trip_updates_df["trip_update_trip_start_time"].fillna(
-            timedelta(hours=0, minutes=0, seconds=0), inplace=True
-        )
-        # Fix trip direction
-        trip_updates_df["trip_update_trip_direction_id"].fillna(-1, inplace=True)
-
-        for i, trip_update in trip_updates_df.iterrows():
-            this_trip_update = TripUpdate(
-                entity_id=trip_update["entity_id"],
-                feed_message=trip_update["feed_message"],
-                trip_trip_id=trip_update["trip_update_trip_trip_id"],
-                trip_route_id=trip_update["trip_update_trip_route_id"],
-                trip_direction_id=trip_update["trip_update_trip_direction_id"],
-                trip_start_time=trip_update["trip_update_trip_start_time"],
-                trip_start_date=trip_update["trip_update_trip_start_date"],
-                trip_schedule_relationship=trip_update[
-                    "trip_update_trip_schedule_relationship"
-                ],
-                vehicle_id=trip_update["trip_update_vehicle_id"],
-                vehicle_label=trip_update["trip_update_vehicle_label"],
-                # trip_update_vehicle_license_plate=trip_update["trip_update_vehicle_license_plate"],
-                # trip_update_vehicle_wheelchair_accessible=trip_update["trip_update_vehicle_wheelchair_accessible"],
-                timestamp=trip_update["trip_update_timestamp"],
-                # trip_update_delay=trip_update["trip_update_delay"],
+        for entity in entities:
+            t = entity.trip_update
+            trip_updates_to_create.append(
+                TripUpdate(
+                    entity_id=entity.id,
+                    feed_message=feed_message,
+                    trip_trip_id=t.trip.trip_id if t.trip.HasField("trip_id") else None,
+                    trip_route_id=t.trip.route_id
+                    if t.trip.HasField("route_id")
+                    else None,
+                    trip_direction_id=t.trip.direction_id
+                    if t.trip.HasField("direction_id")
+                    else None,
+                    trip_start_time=gtfs_time(t.trip.start_time)
+                    if t.trip.HasField("start_time")
+                    else None,
+                    trip_start_date=gtfs_date(t.trip.start_date)
+                    if t.trip.HasField("start_date")
+                    else None,
+                    trip_schedule_relationship=t.trip.schedule_relationship
+                    if t.trip.HasField("schedule_relationship")
+                    else None,
+                    vehicle_id=t.vehicle.id if t.vehicle.HasField("id") else None,
+                    vehicle_label=t.vehicle.label
+                    if t.vehicle.HasField("label")
+                    else None,
+                    vehicle_license_plate=t.vehicle.license_plate
+                    if t.vehicle.HasField("license_plate")
+                    else None,
+                    timestamp=gtfs_timestamp(t.timestamp)
+                    if t.HasField("timestamp")
+                    else None,
+                    delay=t.delay if t.HasField("delay") else None,
+                )
             )
-            # Save this TripUpdate object
-            this_trip_update.save()
 
-            # Build StopTimeUpdate DataFrame
-            stop_time_updates_json = str(trip_update["trip_update_stop_time_update"])
-            stop_time_updates_json = stop_time_updates_json.replace("'", '"')
-            stop_time_updates_json = json.loads(stop_time_updates_json)
-            stop_time_updates_df = pd.json_normalize(stop_time_updates_json, sep="_")
-            stop_time_updates_df["feed_message"] = feed_message
-            stop_time_updates_df["trip_update"] = this_trip_update
+            stop_time_updates_by_trip_index.append(list(t.stop_time_update))
 
-            # Fix arrival time timestamp
-            if "arrival_time" in stop_time_updates_df.columns:
-                stop_time_updates_df["arrival_time"].fillna(
-                    datetime.now().timestamp(), inplace=True
+        if trip_updates_to_create:
+            with transaction.atomic():
+                created_trip_updates = TripUpdate.objects.bulk_create(
+                    trip_updates_to_create,
+                    batch_size=1000,
                 )
-                stop_time_updates_df["arrival_time"] = pd.to_datetime(
-                    stop_time_updates_df["arrival_time"].astype(int), unit="s", utc=True
-                )
-            # Fix departure time timestamp
-            if "departure_time" in stop_time_updates_df.columns:
-                stop_time_updates_df["departure_time"].fillna(
-                    datetime.now().timestamp(), inplace=True
-                )
-                stop_time_updates_df["departure_time"] = pd.to_datetime(
-                    stop_time_updates_df["departure_time"].astype(int),
-                    unit="s",
-                    utc=True,
-                )
-            # Fix arrival uncertainty
-            if "arrival_uncertainty" in stop_time_updates_df.columns:
-                stop_time_updates_df["arrival_uncertainty"].fillna(0, inplace=True)
-            # Fix departure uncertainty
-            if "departure_uncertainty" in stop_time_updates_df.columns:
-                stop_time_updates_df["departure_uncertainty"].fillna(0, inplace=True)
-            # Fix arrival delay
-            if "arrival_delay" in stop_time_updates_df.columns:
-                stop_time_updates_df["arrival_delay"].fillna(0, inplace=True)
-            # Fix departure delay
-            if "departure_delay" in stop_time_updates_df.columns:
-                stop_time_updates_df["departure_delay"].fillna(0, inplace=True)
 
-            # Save to database
-            objects = [
-                StopTimeUpdate(**row)
-                for row in stop_time_updates_df.to_dict(orient="records")
-            ]
-            StopTimeUpdate.objects.bulk_create(objects)
+                stop_time_updates_to_create = []
+                for trip_update, stop_time_updates in zip(
+                    created_trip_updates, stop_time_updates_by_trip_index
+                ):
+                    for stu in stop_time_updates:
+                        stop_time_updates_to_create.append(
+                            StopTimeUpdate(
+                                trip_update=trip_update,
+                                stop_sequence=stu.stop_sequence
+                                if stu.HasField("stop_sequence")
+                                else None,
+                                stop_id=stu.stop_id
+                                if stu.HasField("stop_id")
+                                else None,
+                                arrival_delay=stu.arrival.delay
+                                if stu.arrival.HasField("delay")
+                                else None,
+                                arrival_time=gtfs_timestamp(stu.arrival.time)
+                                if stu.arrival.HasField("time")
+                                else None,
+                                arrival_uncertainty=stu.arrival.uncertainty
+                                if stu.arrival.HasField("uncertainty")
+                                else None,
+                                departure_delay=stu.departure.delay
+                                if stu.departure.HasField("delay")
+                                else None,
+                                departure_time=gtfs_timestamp(stu.departure.time)
+                                if stu.departure.HasField("time")
+                                else None,
+                                departure_uncertainty=stu.departure.uncertainty
+                                if stu.departure.HasField("uncertainty")
+                                else None,
+                                schedule_relationship=stu.schedule_relationship
+                                if stu.HasField("schedule_relationship")
+                                else None,
+                            )
+                        )
+
+                if stop_time_updates_to_create:
+                    StopTimeUpdate.objects.bulk_create(
+                        stop_time_updates_to_create,
+                        batch_size=2000,
+                    )
 
     return "TripUpdates saved to database"
 

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -35,6 +35,7 @@ from feed.models import (
     TranslatedImage,
     LocalizedImage,
 )
+from django.contrib.gis.geos import Point
 
 logging.basicConfig(
     format="%(levelname)s: %(message)s",
@@ -188,16 +189,46 @@ def get_schedule():
                         keep_default_na=False,
                         na_values="",
                     )
+
+                    if table_name == "feed_info" and not table.empty:
+                        feed_info_row = table.iloc[0]
+                        feed_updates = {}
+
+                        start_date = gtfs_date(
+                            normalize_gtfs_value(feed_info_row.get("feed_start_date"))
+                        )
+                        if start_date is not None:
+                            feed_updates["start_date"] = start_date
+
+                        end_date = gtfs_date(
+                            normalize_gtfs_value(feed_info_row.get("feed_end_date"))
+                        )
+                        if end_date is not None:
+                            feed_updates["end_date"] = end_date
+
+                        version = normalize_gtfs_value(
+                            feed_info_row.get("feed_version")
+                        )
+                        if version is not None:
+                            feed_updates["version"] = version
+
+                        if feed_updates:
+                            for field, value in feed_updates.items():
+                                setattr(feed, field, value)
+                            feed.save(update_fields=list(feed_updates.keys()))
+
                     table = table[[col for col in fields if col in table.columns]]
                     table["feed"] = feed
-                    for row in table.to_dict(orient="records"):
-                        instance = model(
+                    instances = [
+                        model(
                             **{
                                 key: normalize_gtfs_value(value)
                                 for key, value in row.items()
                             }
                         )
-                        instance.save()
+                        for row in table.to_dict(orient="records")
+                    ]
+                    model.objects.bulk_create(instances, batch_size=2000)
                     logging.info(f"{file} imported successfully")
 
             logging.info("Schedule updated successfully")
@@ -273,6 +304,10 @@ def get_vehicle_positions():
                     else None,
                     position_longitude=v.position.longitude
                     if v.position.HasField("longitude")
+                    else None,
+                    position_point=Point(v.position.longitude, v.position.latitude)
+                    if v.position.HasField("longitude")
+                    and v.position.HasField("latitude")
                     else None,
                     position_bearing=v.position.bearing
                     if v.position.HasField("bearing")

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -25,6 +25,15 @@ from feed.models import (
     Trip,
     StopTime,
     FeedInfo,
+    Alert,
+    TimeRange,
+    EntitySelector,
+    TripDescriptor,
+    ModifiedTripSelector,
+    TranslatedString,
+    Translation,
+    TranslatedImage,
+    LocalizedImage,
 )
 
 logging.basicConfig(
@@ -432,5 +441,244 @@ def get_trip_updates():
 
 
 @shared_task
-def get_service_alerts():
-    return "Fetching Alerts"
+def get_alerts():
+    def has_optional_field(message, field_name):
+        descriptor = getattr(message, "DESCRIPTOR", None)
+        if descriptor is None or field_name not in descriptor.fields_by_name:
+            return False
+        try:
+            return message.HasField(field_name)
+        except ValueError:
+            return False
+
+    publishers = FeedPublisher.objects.filter(is_active=True)
+    for publisher in publishers:
+        alerts = gtfs_rt.FeedMessage()
+        try:
+            alerts_response = requests.get(publisher.alerts_url, timeout=10)
+            print(f"Fetching alerts from {publisher.alerts_url}")
+            alerts.ParseFromString(alerts_response.content)
+        except requests.RequestException as e:
+            print(f"Error fetching alerts from {publisher.alerts_url}: {str(e)}")
+            continue
+
+        # Save FeedMessage object
+        feed_message = FeedMessage(
+            feed_message_id=f"{publisher.code}-alerts-{alerts.header.timestamp}",
+            publisher=publisher,
+            entity_type="alert",
+            timestamp=gtfs_timestamp(
+                alerts.header.timestamp,
+                timezone=pytz.timezone(publisher.timezone),
+            ),
+            incrementality=alerts.header.incrementality,
+            gtfs_realtime_version=alerts.header.gtfs_realtime_version,
+        )
+        feed_message.save()
+
+        # Save Alert entities and their related InformedEntity, TripDescriptor, ModifiedTripSelector, TranslatedString, Translation, and TranslatedImage objects
+        entities = alerts.entity
+        incoming_entity_ids = [entity.id for entity in entities]
+        existing_entity_ids = set(
+            Alert.objects.filter(entity_id__in=incoming_entity_ids).values_list(
+                "entity_id", flat=True
+            )
+        )
+
+        for entity in entities:
+            if entity.id in existing_entity_ids:
+                continue
+
+            a = entity.alert
+            with transaction.atomic():
+                alert = Alert.objects.create(
+                    entity_id=entity.id,
+                    feed_message=feed_message,
+                    cause=a.cause if a.HasField("cause") else None,
+                    effect=a.effect if a.HasField("effect") else None,
+                    severity_level=a.severity_level
+                    if a.HasField("severity_level")
+                    else None,
+                )
+
+                # active_period can contain multiple ranges per alert.
+                time_ranges_to_create = [
+                    TimeRange(
+                        alert=alert,
+                        field_name="active_period",
+                        start=gtfs_timestamp(period.start)
+                        if period.HasField("start")
+                        else None,
+                        end=gtfs_timestamp(period.end)
+                        if period.HasField("end")
+                        else None,
+                    )
+                    for period in a.active_period
+                ]
+                if time_ranges_to_create:
+                    TimeRange.objects.bulk_create(time_ranges_to_create, batch_size=500)
+
+                # informed_entity can contain multiple selectors per alert.
+                entity_selectors_to_create = []
+                trip_protos = []
+                for ie in a.informed_entity:
+                    entity_selectors_to_create.append(
+                        EntitySelector(
+                            alert=alert,
+                            field_name="informed_entity",
+                            agency_id=ie.agency_id
+                            if ie.HasField("agency_id")
+                            else None,
+                            route_id=ie.route_id if ie.HasField("route_id") else None,
+                            route_type=ie.route_type
+                            if ie.HasField("route_type")
+                            else None,
+                            direction_id=ie.direction_id
+                            if ie.HasField("direction_id")
+                            else None,
+                            stop_id=ie.stop_id if ie.HasField("stop_id") else None,
+                        )
+                    )
+                    trip_protos.append(ie.trip if ie.HasField("trip") else None)
+
+                if entity_selectors_to_create:
+                    created_selectors = EntitySelector.objects.bulk_create(
+                        entity_selectors_to_create, batch_size=500
+                    )
+
+                    trip_descriptors_to_create = []
+                    modified_trip_protos = []
+                    for es, trip_proto in zip(created_selectors, trip_protos):
+                        if trip_proto is None:
+                            continue
+                        trip_descriptors_to_create.append(
+                            TripDescriptor(
+                                entity_selector=es,
+                                field_name="trip",
+                                trip_id=trip_proto.trip_id
+                                if trip_proto.HasField("trip_id")
+                                else None,
+                                route_id=trip_proto.route_id
+                                if trip_proto.HasField("route_id")
+                                else None,
+                                direction_id=trip_proto.direction_id
+                                if trip_proto.HasField("direction_id")
+                                else None,
+                                start_time=gtfs_time(trip_proto.start_time)
+                                if trip_proto.HasField("start_time")
+                                else None,
+                                start_date=gtfs_date(trip_proto.start_date)
+                                if trip_proto.HasField("start_date")
+                                else None,
+                                schedule_relationship=trip_proto.schedule_relationship
+                                if trip_proto.HasField("schedule_relationship")
+                                else None,
+                            )
+                        )
+                        try:
+                            modified_trip_protos.append(
+                                trip_proto.modified_trip
+                                if trip_proto.HasField("modified_trip")
+                                else None
+                            )
+                        except ValueError:
+                            modified_trip_protos.append(None)
+
+                    if trip_descriptors_to_create:
+                        created_trip_descriptors = TripDescriptor.objects.bulk_create(
+                            trip_descriptors_to_create, batch_size=500
+                        )
+
+                        modified_trip_selectors_to_create = [
+                            ModifiedTripSelector(
+                                trip_descriptor=td,
+                                field_name="modified_trip",
+                                modifications_id=mts.modifications_id
+                                if mts.HasField("modifications_id")
+                                else None,
+                                affected_trip_id=mts.affected_trip_id
+                                if mts.HasField("affected_trip_id")
+                                else None,
+                                start_time=gtfs_time(mts.start_time)
+                                if mts.HasField("start_time")
+                                else None,
+                                start_date=gtfs_date(mts.start_date)
+                                if mts.HasField("start_date")
+                                else None,
+                            )
+                            for td, mts in zip(
+                                created_trip_descriptors, modified_trip_protos
+                            )
+                            if mts is not None
+                        ]
+                        if modified_trip_selectors_to_create:
+                            ModifiedTripSelector.objects.bulk_create(
+                                modified_trip_selectors_to_create, batch_size=500
+                            )
+
+                # TranslatedString fields and their Translation children
+                translated_string_fields = [
+                    ("cause_detail", getattr(a, "cause_detail", None)),
+                    ("effect_detail", getattr(a, "effect_detail", None)),
+                    ("url", getattr(a, "url", None)),
+                    ("header_text", getattr(a, "header_text", None)),
+                    ("description_text", getattr(a, "description_text", None)),
+                    ("tts_header_text", getattr(a, "tts_header_text", None)),
+                    (
+                        "tts_description_text",
+                        getattr(a, "tts_description_text", None),
+                    ),
+                    (
+                        "image_alternative_text",
+                        getattr(a, "image_alternative_text", None),
+                    ),
+                ]
+                for field_name, ts_proto in translated_string_fields:
+                    if ts_proto is None or not getattr(ts_proto, "translation", None):
+                        continue
+                    ts = TranslatedString.objects.create(
+                        alert=alert, field_name=field_name
+                    )
+                    Translation.objects.bulk_create(
+                        [
+                            Translation(
+                                translated_string=ts,
+                                field_name="translation",
+                                text=t.text,
+                                language=t.language if t.HasField("language") else None,
+                            )
+                            for t in ts_proto.translation
+                        ],
+                        batch_size=500,
+                    )
+
+                # TranslatedImage and its LocalizedImage children
+                image_proto = getattr(a, "image", None)
+                localized_images = (
+                    list(image_proto.localized_image)
+                    if image_proto is not None
+                    and has_optional_field(a, "image")
+                    and getattr(image_proto, "localized_image", None)
+                    else []
+                )
+                if localized_images:
+                    translated_image = TranslatedImage.objects.create(
+                        alert=alert, field_name="image"
+                    )
+                    LocalizedImage.objects.bulk_create(
+                        [
+                            LocalizedImage(
+                                translated_image=translated_image,
+                                field_name="localized_image",
+                                url=li.url,
+                                media_type=li.media_type,
+                                language=li.language
+                                if li.HasField("language")
+                                else None,
+                            )
+                            for li in localized_images
+                        ],
+                        batch_size=500,
+                    )
+
+    return "ServiceAlerts saved to database"

--- a/backend/feed/admin.py
+++ b/backend/feed/admin.py
@@ -9,7 +9,8 @@ class StopAdmin(admin.GISModelAdmin):
     exclude = ["stop_lat", "stop_lon"]
 
 
-admin.site.register(GTFSProvider)
+admin.site.register(TransitSystem)
+admin.site.register(FeedPublisher)
 admin.site.register(Feed)
 admin.site.register(Agency)
 admin.site.register(Stop, StopAdmin)

--- a/backend/feed/admin.py
+++ b/backend/feed/admin.py
@@ -1,6 +1,38 @@
 from django.contrib.gis import admin
 
-from .models import *
+from .models import (
+    Agency,
+    Alert,
+    Calendar,
+    CalendarDate,
+    EntitySelector,
+    FareAttribute,
+    FareRule,
+    Feed,
+    FeedInfo,
+    FeedMessage,
+    FeedPublisher,
+    GeoShape,
+    LocalizedImage,
+    ModifiedTripSelector,
+    Route,
+    RouteStop,
+    Shape,
+    Stop,
+    StopTime,
+    StopTimeUpdate,
+    TimeRange,
+    TransitSystem,
+    TranslatedImage,
+    TranslatedString,
+    Translation,
+    Trip,
+    TripDescriptor,
+    TripDuration,
+    TripTime,
+    TripUpdate,
+    VehiclePosition,
+)
 
 # Register your models here.
 
@@ -31,3 +63,12 @@ admin.site.register(FeedMessage)
 admin.site.register(TripUpdate)
 admin.site.register(StopTimeUpdate)
 admin.site.register(VehiclePosition, admin.GISModelAdmin)
+admin.site.register(Alert)
+admin.site.register(TimeRange)
+admin.site.register(EntitySelector)
+admin.site.register(TripDescriptor)
+admin.site.register(ModifiedTripSelector)
+admin.site.register(TranslatedString)
+admin.site.register(Translation)
+admin.site.register(TranslatedImage)
+admin.site.register(LocalizedImage)

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -25,21 +25,61 @@ def validate_no_spaces_or_special_symbols(value):
         )
 
 
-class GTFSProvider(models.Model):
-    """A provider provides transportation services GTFS data.
+# --------------
+# Transit system
+# --------------
+
+
+class TransitSystem(models.Model):
+    """A transit system is a collection of GTFS providers that serve a common purpose, for example, the public transportation system of a city or country."""
+
+    name = models.CharField(
+        max_length=255, help_text="Nombre del sistema de transporte."
+    )
+    description = models.TextField(
+        blank=True, null=True, help_text="Descripción del sistema de transporte."
+    )
+
+    def __str__(self):
+        return self.name
+
+
+class FeedPublisher(models.Model):
+    """A feed publisher provides transportation services GTFS data.
 
     It might or might not be the same as the agency in the GTFS feed. A GTFS provider can serve multiple agencies.
     """
 
-    provider_id = models.BigAutoField(primary_key=True)
+    transit_system = models.ForeignKey(
+        TransitSystem,
+        blank=True,
+        null=True,
+        help_text="Sistema de transporte al que sirve el proveedor de datos.",
+        on_delete=models.SET_NULL,
+    )
     code = models.CharField(
         max_length=31,
         help_text="Código (típicamente el acrónimo) de la empresa. No debe tener espacios ni símbolos especiales.",
         validators=[validate_no_spaces_or_special_symbols],
+        unique=True,
     )
     name = models.CharField(max_length=255, help_text="Nombre de la empresa.")
     description = models.TextField(
         blank=True, null=True, help_text="Descripción de la institución o empresa."
+    )
+    lang = models.CharField(
+        max_length=15,
+        blank=True,
+        null=True,
+        help_text="Idioma de los datos proporcionados por el proveedor, en formato ISO 639-1 alpha-2 o alpha-3. Ejemplo: es, en, fr.",
+    )
+    contact_email = models.EmailField(
+        blank=True,
+        null=True,
+        help_text="Correo electrónico de contacto del proveedor de datos.",
+    )
+    contact_url = models.URLField(
+        blank=True, null=True, help_text="URL de contacto del proveedor de datos."
     )
     website = models.URLField(
         blank=True, null=True, help_text="Sitio web de la empresa."
@@ -59,7 +99,7 @@ class GTFSProvider(models.Model):
         null=True,
         help_text="URL del suministro (FeedMessage) de la entidad GTFS Realtime VehiclePositions (.pb).",
     )
-    service_alerts_url = models.URLField(
+    alerts_url = models.URLField(
         blank=True,
         null=True,
         help_text="URL del suministro (FeedMessage) de la entidad GTFS Realtime ServiceAlerts (.pb).",
@@ -77,16 +117,18 @@ class GTFSProvider(models.Model):
         return f"{self.name} ({self.code})"
 
 
-# -------------
-# GTFS Schedule
-# -------------
-
-
 class Feed(models.Model):
+    """
+    A GTFS Schedule feed.
+    """
+
     feed_id = models.CharField(max_length=100, primary_key=True, unique=True)
-    gtfs_provider = models.ForeignKey(
-        GTFSProvider, on_delete=models.SET_NULL, blank=True, null=True
+    feed_publisher = models.ForeignKey(
+        FeedPublisher, on_delete=models.SET_NULL, blank=True, null=True
     )
+    start_date = models.DateField(blank=True, null=True)
+    end_date = models.DateField(blank=True, null=True)
+    version = models.CharField(max_length=255, blank=True, null=True)
     http_etag = models.CharField(max_length=1023, blank=True, null=True)
     http_last_modified = models.DateTimeField(blank=True, null=True)
     is_current = models.BooleanField(blank=True, null=True)
@@ -94,6 +136,38 @@ class Feed(models.Model):
 
     def __str__(self):
         return self.feed_id
+
+
+class FeedMessage(models.Model):
+    """
+    A GTFS Realtime feed message.
+    """
+
+    ENTITY_TYPE_CHOICES = (
+        ("trip_update", "TripUpdate"),
+        ("vehicle", "VehiclePosition"),
+        ("alert", "Alert"),
+    )
+
+    feed_message_id = models.CharField(max_length=63, primary_key=True)
+    publisher = models.ForeignKey(
+        FeedPublisher, on_delete=models.SET_NULL, blank=True, null=True
+    )
+    entity_type = models.CharField(max_length=63, choices=ENTITY_TYPE_CHOICES)
+    timestamp = models.DateTimeField(auto_now=True)
+    incrementality = models.CharField(max_length=15)
+    gtfs_realtime_version = models.CharField(max_length=15)
+
+    class Meta:
+        ordering = ["-timestamp"]
+
+    def __str__(self):
+        return f"{self.entity_type} ({self.timestamp})"
+
+
+# -------------
+# GTFS Schedule
+# -------------
 
 
 class Agency(BaseAgency):
@@ -149,7 +223,13 @@ class Stop(BaseStop):
             self.stop_lat = self.stop_point.y
             self.stop_lon = self.stop_point.x
         else:
-            self.stop_point = Point(self.stop_lon, self.stop_lat)
+            if self.stop_lon is not None and self.stop_lat is not None:
+                try:
+                    self.stop_point = Point(float(self.stop_lon), float(self.stop_lat))
+                except (TypeError, ValueError):
+                    self.stop_point = None
+            else:
+                self.stop_point = None
         super(Stop, self).save(*args, **kwargs)
 
     def __str__(self):
@@ -212,6 +292,8 @@ class CalendarDate(BaseCalendarDate):
     )
     holiday_name = models.CharField(
         max_length=255,
+        blank=True,
+        null=True,
         default="Feriado",
         help_text="Nombre de la festividad o feriado.",
     )
@@ -557,35 +639,6 @@ class TripTime(models.Model):
 # -------------
 
 
-class FeedMessage(models.Model):
-    """
-    Header of a GTFS Realtime FeedMessage.
-
-    This is metadata to link records of other models to a retrieved FeedMessage containing several entities, typically (necessarily, in this implementation) of a single kind.
-    """
-
-    ENTITY_TYPE_CHOICES = (
-        ("trip_update", "TripUpdate"),
-        ("vehicle", "VehiclePosition"),
-        ("alert", "Alert"),
-    )
-
-    feed_message_id = models.CharField(max_length=63, primary_key=True)
-    provider = models.ForeignKey(
-        GTFSProvider, on_delete=models.SET_NULL, blank=True, null=True
-    )
-    entity_type = models.CharField(max_length=63, choices=ENTITY_TYPE_CHOICES)
-    timestamp = models.DateTimeField(auto_now=True)
-    incrementality = models.CharField(max_length=15)
-    gtfs_realtime_version = models.CharField(max_length=15)
-
-    class Meta:
-        ordering = ["-timestamp"]
-
-    def __str__(self):
-        return f"{self.entity_type} ({self.timestamp})"
-
-
 class TripUpdate(models.Model):
     """
     GTFS Realtime TripUpdate entity v2.0 (normalized).
@@ -635,9 +688,6 @@ class StopTimeUpdate(models.Model):
     """
 
     id = models.BigAutoField(primary_key=True)
-
-    # Foreign key to FeedMessage and TripUpdate models
-    feed_message = models.ForeignKey(FeedMessage, on_delete=models.CASCADE)
     trip_update = models.ForeignKey(TripUpdate, on_delete=models.CASCADE)
 
     # Stop ID (string)
@@ -653,9 +703,6 @@ class StopTimeUpdate(models.Model):
     departure_delay = models.IntegerField(blank=True, null=True)
     departure_time = models.DateTimeField(blank=True, null=True)
     departure_uncertainty = models.IntegerField(blank=True, null=True)
-
-    # OccupancyStatus (enum)
-    departure_occupancy_status = models.CharField(max_length=255, blank=True, null=True)
 
     # ScheduleRelationship (enum)
     schedule_relationship = models.CharField(max_length=255, blank=True, null=True)
@@ -680,60 +727,107 @@ class VehiclePosition(models.Model):
     )
 
     # TripDescriptor (message)
-    vehicle_trip_trip_id = models.CharField(max_length=255)
-    vehicle_trip_route_id = models.CharField(max_length=255, blank=True, null=True)
-    vehicle_trip_direction_id = models.IntegerField(blank=True, null=True)
-    vehicle_trip_start_time = models.DurationField(blank=True, null=True)
-    vehicle_trip_start_date = models.DateField(blank=True, null=True)
-    vehicle_trip_schedule_relationship = models.CharField(
-        max_length=31, blank=True, null=True
+    trip_trip_id = models.CharField(max_length=255)
+    trip_route_id = models.CharField(max_length=255, blank=True, null=True)
+    trip_direction_id = models.IntegerField(blank=True, null=True)
+    trip_start_time = models.DurationField(blank=True, null=True)
+    trip_start_date = models.DateField(blank=True, null=True)
+    trip_schedule_relationship = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=(
+            (0, "SCHEDULED"),
+            (1, "ADDED"),
+            (2, "UNSCHEDULED"),
+            (3, "CANCELED"),
+            (4, "REPLACEMENT"),
+            (5, "DUPLICATED"),
+            (6, "NEW"),
+            (7, "DELETED"),
+        ),
     )  # (enum)
 
     # VehicleDescriptor (message)
-    vehicle_vehicle_id = models.CharField(max_length=255, blank=True, null=True)
-    vehicle_vehicle_label = models.CharField(max_length=255, blank=True, null=True)
-    vehicle_vehicle_license_plate = models.CharField(
-        max_length=255, blank=True, null=True
-    )
-    vehicle_vehicle_wheelchair_accessible = models.CharField(
+    vehicle_id = models.CharField(max_length=255, blank=True, null=True)
+    vehicle_label = models.CharField(max_length=255, blank=True, null=True)
+    vehicle_license_plate = models.CharField(max_length=255, blank=True, null=True)
+    vehicle_wheelchair_accessible = models.CharField(
         max_length=31, blank=True, null=True
     )  # (enum)
 
     # Position (message)
-    vehicle_position_latitude = models.FloatField(blank=True, null=True)
-    vehicle_position_longitude = models.FloatField(blank=True, null=True)
-    vehicle_position_point = models.PointField(srid=4326, blank=True, null=True)
-    vehicle_position_bearing = models.FloatField(blank=True, null=True)
-    vehicle_position_odometer = models.FloatField(blank=True, null=True)
-    vehicle_position_speed = models.FloatField(blank=True, null=True)  # (meters/second)
+    position_latitude = models.FloatField(blank=True, null=True)
+    position_longitude = models.FloatField(blank=True, null=True)
+    position_point = models.PointField(srid=4326, blank=True, null=True)
+    position_bearing = models.FloatField(blank=True, null=True)
+    position_odometer = models.FloatField(blank=True, null=True)
+    position_speed = models.FloatField(blank=True, null=True)  # (meters/second)
 
     # Current stop sequence (uint32)
-    vehicle_current_stop_sequence = models.IntegerField(blank=True, null=True)
+    current_stop_sequence = models.IntegerField(blank=True, null=True)
 
     # Stop ID (string)
-    vehicle_stop_id = models.CharField(max_length=255, blank=True, null=True)
+    stop_id = models.CharField(max_length=255, blank=True, null=True)
 
     # VehicleStopStatus (enum)
-    vehicle_current_status = models.CharField(max_length=255, blank=True, null=True)
+    current_status = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=(
+            (0, "INCOMING_AT"),
+            (1, "STOPPED_AT"),
+            (2, "IN_TRANSIT_TO"),
+        ),
+    )
 
     # Timestamp (uint64)
-    vehicle_timestamp = models.DateTimeField(blank=True, null=True)
+    timestamp = models.DateTimeField(blank=True, null=True)
 
     # CongestionLevel (enum)
-    vehicle_congestion_level = models.CharField(max_length=255, blank=True, null=True)
+    congestion_level = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=(
+            (0, "UNKNOWN_CONGESTION_LEVEL"),
+            (1, "RUNNING_SMOOTHLY"),
+            (2, "STOP_AND_GO"),
+            (3, "CONGESTION"),
+            (4, "SEVERE_CONGESTION"),
+        ),
+    )
 
     # OccupancyStatus (enum)
-    vehicle_occupancy_status = models.CharField(max_length=255, blank=True, null=True)
+    occupancy_status = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=(
+            (0, "EMPTY"),
+            (1, "MANY_SEATS_AVAILABLE"),
+            (2, "FEW_SEATS_AVAILABLE"),
+            (3, "STANDING_ROOM_ONLY"),
+            (4, "CRUSHED_STANDING_ROOM_ONLY"),
+            (5, "FULL"),
+            (6, "NOT_ACCEPTING_PASSENGERS"),
+            (7, "NO_DATA_AVAILABLE"),
+            (8, "NOT_BOARDABLE"),
+        ),
+    )
 
     # OccupancyPercentage (uint32)
-    vehicle_occupancy_percentage = models.FloatField(blank=True, null=True)
+    occupancy_percentage = models.IntegerField(blank=True, null=True)
 
     # CarriageDetails (message): not implemented
 
     def save(self, *args, **kwargs):
-        self.vehicle_position_point = Point(
-            self.vehicle_position_longitude, self.vehicle_position_latitude
-        )
+        if self.position_longitude is not None and self.position_latitude is not None:
+            try:
+                self.position_point = Point(
+                    float(self.position_longitude), float(self.position_latitude)
+                )
+            except (TypeError, ValueError):
+                self.position_point = None
+        else:
+            self.position_point = None
         super(VehiclePosition, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -835,78 +835,140 @@ class VehiclePosition(models.Model):
 
 
 class Alert(models.Model):
-    """Alerts and warnings about the service.
-    Maps to alerts.txt in the GTFS feed.
-
-    TODO: ajustar con Alerts de GTFS Realtime
-    """
-
     id = models.BigAutoField(primary_key=True)
-    feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    alert_id = models.CharField(
-        max_length=255, help_text="Identificador único de la alerta."
+    entity_id = models.CharField(max_length=127)
+    feed_message = models.ForeignKey(
+        FeedMessage, on_delete=models.CASCADE, blank=True, null=True
     )
-    route_id = models.CharField(max_length=255, help_text="Identificador de la ruta.")
-    trip_id = models.CharField(max_length=255, help_text="Identificador del viaje.")
-    service_date = models.DateField(
-        help_text="Fecha del servicio descrito por la alerta."
-    )
-    service_start_time = models.TimeField(
-        help_text="Hora de inicio del servicio descrito por la alerta."
-    )
-    service_end_time = models.TimeField(
-        help_text="Hora de finalización del servicio descrito por la alerta."
-    )
-    alert_header = models.CharField(
-        max_length=255, help_text="Encabezado de la alerta."
-    )
-    alert_description = models.TextField(help_text="Descripción de la alerta.")
-    alert_url = models.URLField(blank=True, null=True, help_text="URL de la alerta.")
-    cause = models.PositiveIntegerField(
+    cause = models.IntegerField(
+        blank=True,
+        null=True,
         choices=(
-            (1, "Otra causa"),
-            (2, "Accidente"),
-            (3, "Congestión"),
-            (4, "Evento"),
-            (5, "Mantenimiento"),
-            (6, "Planificado"),
-            (7, "Huelga"),
-            (8, "Manifestación"),
-            (9, "Demora"),
-            (10, "Cierre"),
+            (1, "UNKNOWN_CAUSE"),
+            (2, "OTHER_CAUSE"),
+            (3, "TECHNICAL_PROBLEM"),
+            (4, "STRIKE"),
+            (5, "DEMONSTRATION"),
+            (6, "ACCIDENT"),
+            (7, "HOLIDAY"),
+            (8, "WEATHER"),
+            (9, "MAINTENANCE"),
+            (10, "CONSTRUCTION"),
+            (11, "POLICE_ACTIVITY"),
+            (12, "MEDICAL_EMERGENCY"),
         ),
-        help_text="Causa de la alerta.",
     )
-    effect = models.PositiveIntegerField(
+    effect = models.IntegerField(
+        blank=True,
+        null=True,
         choices=(
-            (1, "Otro efecto"),
-            (2, "Desviación"),
-            (3, "Adelanto"),
-            (4, "Cancelación"),
-            (5, "Cierre"),
-            (6, "Desvío"),
-            (7, "Detención"),
-            (8, "Desconocido"),
+            (1, "NO_SERVICE"),
+            (2, "REDUCED_SERVICE"),
+            (3, "SIGNIFICANT_DELAYS"),
+            (4, "DETOUR"),
+            (5, "ADDITIONAL_SERVICE"),
+            (6, "MODIFIED_SERVICE"),
+            (7, "OTHER_EFFECT"),
+            (8, "UNKNOWN_EFFECT"),
+            (9, "STOP_MOVED"),
+            (10, "NO_EFFECT"),
+            (11, "ACCESSIBILITY_ISSUE"),
         ),
-        help_text="Efecto de la alerta.",
     )
-    severity = models.PositiveIntegerField(
+    severity_level = models.IntegerField(
+        blank=True,
+        null=True,
         choices=(
-            (1, "Desconocido"),
-            (2, "Información"),
-            (3, "Advertencia"),
-            (4, "Grave"),
-            (5, "Muy grave"),
+            (1, "UNKNOWN_SEVERITY"),
+            (2, "INFO"),
+            (3, "WARNING"),
+            (4, "SEVERE"),
         ),
-        help_text="Severidad de la alerta.",
     )
-    published = models.DateTimeField(
-        help_text="Fecha y hora de publicación de la alerta."
-    )
-    updated = models.DateTimeField(
-        help_text="Fecha y hora de actualización de la alerta."
-    )
-    informed_entity = models.JSONField(help_text="Entidades informadas por la alerta.")
 
-    def __str__(self):
-        return self.alert_id
+
+class ActivePeriod(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    start = models.DateTimeField(blank=True, null=True)
+    end = models.DateTimeField(blank=True, null=True)
+
+
+class InformedEntity(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    agency_id = models.CharField(max_length=255, blank=True, null=True)
+    route_id = models.CharField(max_length=255, blank=True, null=True)
+    route_type = models.IntegerField(blank=True, null=True)
+    direction_id = models.IntegerField(blank=True, null=True)
+    stop_id = models.CharField(max_length=255, blank=True, null=True)
+
+
+class TripDescriptor(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    informed_entity = models.ForeignKey(
+        InformedEntity, on_delete=models.CASCADE, blank=True, null=True
+    )
+    trip_id = models.CharField(max_length=255, blank=True, null=True)
+    route_id = models.CharField(max_length=255, blank=True, null=True)
+    direction_id = models.IntegerField(blank=True, null=True)
+    start_time = models.DurationField(blank=True, null=True)
+    start_date = models.DateField(blank=True, null=True)
+    schedule_relationship = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=(
+            (0, "SCHEDULED"),
+            (1, "ADDED"),
+            (2, "UNSCHEDULED"),
+            (3, "CANCELED"),
+            (4, "REPLACEMENT"),
+            (5, "DUPLICATED"),
+            (6, "NEW"),
+            (7, "DELETED"),
+        ),
+    )
+
+
+class ModifiedTripSelector(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    trip_descriptor = models.ForeignKey(
+        TripDescriptor, on_delete=models.CASCADE, blank=True, null=True
+    )
+    modifications_id = models.CharField(max_length=255, blank=True, null=True)
+    affected_trip_id = models.CharField(max_length=255, blank=True, null=True)
+    start_time = models.DurationField(blank=True, null=True)
+    start_date = models.DateField(blank=True, null=True)
+
+
+class TranslatedString(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(
+            ("cause_detail", "Cause detail"),
+            ("effect_detail", "Effect detail"),
+            ("url", "URL"),
+            ("header_text", "Header text"),
+            ("description_text", "Description text"),
+            ("tts_header_text", "TTS header text"),
+            ("tts_description_text", "TTS description text"),
+            ("image_alternative_text", "Image alternative text"),
+        ),
+    )
+    language = models.CharField(max_length=15, blank=True, null=True)
+    text = models.TextField(blank=True, null=True)
+
+
+class TranslatedImage(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    field_name = models.CharField(
+        max_length=255, blank=True, null=True, choices=(("image", "Image"),)
+    )
+    url = models.URLField(blank=True, null=True)
+    media_type = models.CharField(max_length=255, blank=True, null=True)
+    language = models.CharField(max_length=15, blank=True, null=True)

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -835,7 +835,6 @@ class VehiclePosition(models.Model):
 
 
 class Alert(models.Model):
-    id = models.BigAutoField(primary_key=True)
     entity_id = models.CharField(max_length=127)
     feed_message = models.ForeignKey(
         FeedMessage, on_delete=models.CASCADE, blank=True, null=True
@@ -887,16 +886,26 @@ class Alert(models.Model):
     )
 
 
-class ActivePeriod(models.Model):
-    id = models.BigAutoField(primary_key=True)
+class TimeRange(models.Model):
     alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("active_period", "Active period"),),
+    )
     start = models.DateTimeField(blank=True, null=True)
     end = models.DateTimeField(blank=True, null=True)
 
 
-class InformedEntity(models.Model):
-    id = models.BigAutoField(primary_key=True)
+class EntitySelector(models.Model):
     alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("informed_entity", "Informed entity"),),
+    )
     agency_id = models.CharField(max_length=255, blank=True, null=True)
     route_id = models.CharField(max_length=255, blank=True, null=True)
     route_type = models.IntegerField(blank=True, null=True)
@@ -905,9 +914,14 @@ class InformedEntity(models.Model):
 
 
 class TripDescriptor(models.Model):
-    id = models.BigAutoField(primary_key=True)
-    informed_entity = models.ForeignKey(
-        InformedEntity, on_delete=models.CASCADE, blank=True, null=True
+    entity_selector = models.ForeignKey(
+        EntitySelector, on_delete=models.CASCADE, blank=True, null=True
+    )
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("trip", "Trip"),),
     )
     trip_id = models.CharField(max_length=255, blank=True, null=True)
     route_id = models.CharField(max_length=255, blank=True, null=True)
@@ -931,9 +945,14 @@ class TripDescriptor(models.Model):
 
 
 class ModifiedTripSelector(models.Model):
-    id = models.BigAutoField(primary_key=True)
     trip_descriptor = models.ForeignKey(
         TripDescriptor, on_delete=models.CASCADE, blank=True, null=True
+    )
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("modified_trip", "Modified trip"),),
     )
     modifications_id = models.CharField(max_length=255, blank=True, null=True)
     affected_trip_id = models.CharField(max_length=255, blank=True, null=True)
@@ -942,7 +961,6 @@ class ModifiedTripSelector(models.Model):
 
 
 class TranslatedString(models.Model):
-    id = models.BigAutoField(primary_key=True)
     alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
     field_name = models.CharField(
         max_length=255,
@@ -959,15 +977,38 @@ class TranslatedString(models.Model):
             ("image_alternative_text", "Image alternative text"),
         ),
     )
-    language = models.CharField(max_length=15, blank=True, null=True)
+
+
+class Translation(models.Model):
+    translated_string = models.ForeignKey(
+        TranslatedString, on_delete=models.CASCADE, blank=True, null=True
+    )
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("translation", "Translation"),),
+    )
     text = models.TextField(blank=True, null=True)
+    language = models.CharField(max_length=15, blank=True, null=True)
 
 
 class TranslatedImage(models.Model):
-    id = models.BigAutoField(primary_key=True)
     alert = models.ForeignKey(Alert, on_delete=models.CASCADE, blank=True, null=True)
     field_name = models.CharField(
         max_length=255, blank=True, null=True, choices=(("image", "Image"),)
+    )
+
+
+class LocalizedImage(models.Model):
+    translated_image = models.ForeignKey(
+        TranslatedImage, on_delete=models.CASCADE, blank=True, null=True
+    )
+    field_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        choices=(("localized_image", "Localized image"),),
     )
     url = models.URLField(blank=True, null=True)
     media_type = models.CharField(max_length=255, blank=True, null=True)

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -160,6 +160,12 @@ class FeedMessage(models.Model):
 
     class Meta:
         ordering = ["-timestamp"]
+        indexes = [
+            models.Index(
+                fields=["publisher", "entity_type"],
+                name="feedmessage_publisher_type_idx",
+            ),
+        ]
 
     def __str__(self):
         return f"{self.entity_type} ({self.timestamp})"
@@ -192,24 +198,26 @@ class Stop(BaseStop):
     Maps to stops.txt in the GTFS feed.
     """
 
-    STOP_HEADING_CHOICES = (
-        ("N", "norte"),
-        ("NE", "noreste"),
-        ("E", "este"),
-        ("SE", "sureste"),
-        ("S", "sur"),
-        ("SW", "suroeste"),
-        ("W", "oeste"),
-        ("NW", "noroeste"),
-    )
-
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
 
     stop_point = models.PointField(
-        blank=True, null=True, help_text="Punto georreferenciado de la parada."
+        blank=True,
+        null=True,
     )
     stop_heading = models.CharField(
-        max_length=2, blank=True, null=True, choices=STOP_HEADING_CHOICES
+        max_length=2,
+        blank=True,
+        null=True,
+        choices=(
+            ("N", "north"),
+            ("NE", "northeast"),
+            ("E", "east"),
+            ("SE", "southeast"),
+            ("S", "south"),
+            ("SW", "southwest"),
+            ("W", "west"),
+            ("NW", "northwest"),
+        ),
     )
 
     class Meta:
@@ -244,20 +252,11 @@ class Route(BaseRoute):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_agency = models.ForeignKey(
-        Agency, on_delete=models.CASCADE, blank=True, null=True
-    )
 
     class Meta:
         constraints = [
             UniqueConstraint(fields=["feed", "route_id"], name="unique_route_in_feed")
         ]
-
-    def save(self, *args, **kwargs):
-        self.linked_agency = Agency.objects.get(
-            feed=self.feed, agency_id=self.agency_id
-        )
-        super(Route, self).save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.route_short_name}: {self.route_long_name}"
@@ -287,9 +286,6 @@ class CalendarDate(BaseCalendarDate):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_service = models.ForeignKey(
-        Calendar, on_delete=models.CASCADE, blank=True, null=True
-    )
     holiday_name = models.CharField(
         max_length=255,
         blank=True,
@@ -304,12 +300,6 @@ class CalendarDate(BaseCalendarDate):
                 fields=["feed", "service_id", "date"], name="unique_date_in_feed"
             )
         ]
-
-    def save(self, *args, **kwargs):
-        self.linked_service = Calendar.objects.get(
-            feed=self.feed, service_id=self.service_id
-        )
-        super(CalendarDate, self).save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.holiday_name} ({self.service_id})"
@@ -340,27 +330,11 @@ class Trip(BaseTrip):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_route = models.ForeignKey(
-        Route, on_delete=models.CASCADE, blank=True, null=True
-    )
-    linked_service = models.ForeignKey(
-        Calendar, on_delete=models.CASCADE, blank=True, null=True
-    )
-    geoshape = models.ForeignKey(
-        "GeoShape", on_delete=models.SET_NULL, blank=True, null=True
-    )
 
     class Meta:
         constraints = [
             UniqueConstraint(fields=["feed", "trip_id"], name="unique_trip_in_feed")
         ]
-
-    def save(self, *args, **kwargs):
-        self.linked_route = Route.objects.get(feed=self.feed, route_id=self.route_id)
-        self.linked_service = Calendar.objects.get(
-            feed=self.feed, service_id=self.service_id
-        )
-        super(Trip, self).save(*args, **kwargs)
 
     def __str__(self):
         return self.trip_id
@@ -372,12 +346,6 @@ class StopTime(BaseStopTime):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_trip = models.ForeignKey(
-        Trip, on_delete=models.CASCADE, blank=True, null=True
-    )
-    linked_stop = models.ForeignKey(
-        Stop, on_delete=models.CASCADE, blank=True, null=True
-    )
 
     class Meta:
         constraints = [
@@ -386,11 +354,6 @@ class StopTime(BaseStopTime):
                 name="unique_stoptime_in_feed",
             )
         ]
-
-    def save(self, *args, **kwargs):
-        self.linked_trip = Trip.objects.get(feed=self.feed, trip_id=self.trip_id)
-        self.linked_stop = Stop.objects.get(feed=self.feed, stop_id=self.stop_id)
-        super(StopTime, self).save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.trip_id}: {self.stop_id} ({self.stop_sequence})"
@@ -402,9 +365,6 @@ class FareAttribute(BaseFareAttribute):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_agency = models.ForeignKey(
-        Agency, on_delete=models.CASCADE, blank=True, null=True
-    )
 
     class Meta:
         constraints = [
@@ -412,13 +372,6 @@ class FareAttribute(BaseFareAttribute):
                 fields=["feed", "fare_id"], name="unique_fareattribute_in_feed"
             )
         ]
-
-    def save(self, *args, **kwargs):
-        if self.agency_id:
-            self.linked_agency = Agency.objects.get(
-                feed=self.feed, agency_id=self.agency_id
-            )
-        super(FareAttribute, self).save(*args, **kwargs)
 
     def __str__(self):
         return self.fare_id
@@ -430,12 +383,6 @@ class FareRule(BaseFareRule):
     """
 
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
-    linked_fare = models.ForeignKey(
-        FareAttribute, on_delete=models.CASCADE, blank=True, null=True
-    )
-    linked_route = models.ForeignKey(
-        Route, on_delete=models.CASCADE, blank=True, null=True
-    )
 
     class Meta:
         constraints = [
@@ -451,13 +398,6 @@ class FareRule(BaseFareRule):
                 name="unique_fare_rule_in_feed",
             )
         ]
-
-    def save(self, *args, **kwargs):
-        self.linked_fare = FareAttribute.objects.get(
-            feed=self.feed, fare_id=self.fare_id
-        )
-        self.linked_route = Route.objects.get(feed=self.feed, route_id=self.route_id)
-        super(FareRule, self).save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.fare_id}: {self.route_id}"
@@ -647,7 +587,7 @@ class TripUpdate(models.Model):
     """
 
     id = models.BigAutoField(primary_key=True)
-    entity_id = models.CharField(max_length=127)
+    entity_id = models.CharField(max_length=127, db_index=True)
 
     # Foreign key to FeedMessage model
     feed_message = models.ForeignKey("FeedMessage", on_delete=models.CASCADE)
@@ -675,6 +615,12 @@ class TripUpdate(models.Model):
 
     # Delay (int32)
     delay = models.IntegerField(blank=True, null=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["trip_trip_id"], name="tripupdate_trip_id_idx"),
+            models.Index(fields=["trip_route_id"], name="tripupdate_route_id_idx"),
+        ]
 
     def __str__(self):
         return f"{self.entity_id} ({self.feed_message})"
@@ -719,7 +665,7 @@ class VehiclePosition(models.Model):
     """
 
     id = models.BigAutoField(primary_key=True)
-    entity_id = models.CharField(max_length=127)
+    entity_id = models.CharField(max_length=127, db_index=True)
 
     # Foreign key to FeedMessage model
     feed_message = models.ForeignKey(
@@ -818,6 +764,13 @@ class VehiclePosition(models.Model):
 
     # CarriageDetails (message): not implemented
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["trip_route_id"], name="vehiclepos_route_id_idx"),
+            models.Index(fields=["trip_trip_id"], name="vehiclepos_trip_id_idx"),
+            models.Index(fields=["timestamp"], name="vehiclepos_timestamp_idx"),
+        ]
+
     def save(self, *args, **kwargs):
         if self.position_longitude is not None and self.position_latitude is not None:
             try:
@@ -835,7 +788,7 @@ class VehiclePosition(models.Model):
 
 
 class Alert(models.Model):
-    entity_id = models.CharField(max_length=127)
+    entity_id = models.CharField(max_length=127, db_index=True)
     feed_message = models.ForeignKey(
         FeedMessage, on_delete=models.CASCADE, blank=True, null=True
     )

--- a/backend/infobus/celery.py
+++ b/backend/infobus/celery.py
@@ -28,8 +28,8 @@ def debug_task(self):
 # --------------------
 
 app.conf.beat_schedule = {
-    "hello-world-every-20s": {
+    "hello-world-every-180s": {
         "task": "engine.tasks.hello_world",
-        "schedule": timedelta(seconds=20),
+        "schedule": timedelta(seconds=180),
     },
 }

--- a/backend/infobus/settings.py
+++ b/backend/infobus/settings.py
@@ -168,7 +168,7 @@ CHANNEL_LAYERS = {
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
-LANGUAGE_CODE = "es-cr"
+LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "America/Costa_Rica"
 

--- a/backend/playground.ipynb
+++ b/backend/playground.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe5b1c48",
+   "metadata": {},
+   "source": [
+    "# Testing GTFS Realtime feed messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "c147c0a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.transit import gtfs_realtime_pb2 as gtfs_rt\n",
+    "import requests\n",
+    "\n",
+    "vehicle_positions = gtfs_rt.FeedMessage()\n",
+    "trip_updates = gtfs_rt.FeedMessage()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "0c059867",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1043434"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vehicle_positions_url = \"https://cdn.mbta.com/realtime/VehiclePositions.pb\"\n",
+    "trip_updates_url = \"https://cdn.mbta.com/realtime/TripUpdates.pb\"\n",
+    "\n",
+    "vehicle_positions_response = requests.get(vehicle_positions_url)\n",
+    "vehicle_positions.ParseFromString(vehicle_positions_response.content)\n",
+    "\n",
+    "trip_updates_response = requests.get(trip_updates_url)\n",
+    "trip_updates.ParseFromString(trip_updates_response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "7c35bcbb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1778706397 0 2.0\n",
+      "1652\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\n",
+    "    trip_updates.header.timestamp,\n",
+    "    trip_updates.header.incrementality,\n",
+    "    trip_updates.header.gtfs_realtime_version,\n",
+    ")\n",
+    "\n",
+    "print(len(trip_updates.entity))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "f5ce3955",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "38\n",
+      "True\n",
+      "39\n",
+      "True\n",
+      "40\n",
+      "True\n",
+      "41\n",
+      "True\n",
+      "42\n",
+      "True\n",
+      "43\n",
+      "True\n",
+      "44\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "entities = trip_updates.entity\n",
+    "\n",
+    "entity = entities[0]\n",
+    "t = entity.trip_update\n",
+    "stop_time_updates = t.stop_time_update\n",
+    "\n",
+    "for stu in stop_time_updates:\n",
+    "    stop_sequence = stu.stop_sequence\n",
+    "    print(stop_sequence)\n",
+    "    print(stu.HasField(\"stop_sequence\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "f4af19af",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = entity.vehicle\n",
+    "v.position.HasField(\"latitude\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7b4c45e",
+   "metadata": {},
+   "source": [
+    "# Testing GTFS Schedule importing and updating"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c13886c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import zipfile\n",
+    "import io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fe12b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schedule_url = \"https://cdn.mbta.com/MBTA_GTFS.zip\"\n",
+    "last_feed_tag = {\"value\": None}\n",
+    "schedule_check = requests.head(schedule_url)\n",
+    "feed_tag = schedule_check.headers[\"ETag\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a0118071",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\"510a03f14fcd58bb2d63e4bd165b0aa2-3\"'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "feed_tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "10c18f5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schedule_response = requests.get(schedule_url)\n",
+    "schedule_zip = zipfile.ZipFile(io.BytesIO(schedule_response.content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8ff80eb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "infobus (3.14.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/backend/playground.ipynb
+++ b/backend/playground.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 4,
    "id": "c147c0a3",
    "metadata": {},
    "outputs": [],
@@ -19,22 +19,23 @@
     "import requests\n",
     "\n",
     "vehicle_positions = gtfs_rt.FeedMessage()\n",
-    "trip_updates = gtfs_rt.FeedMessage()"
+    "trip_updates = gtfs_rt.FeedMessage()\n",
+    "alerts = gtfs_rt.FeedMessage()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 7,
    "id": "0c059867",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1043434"
+       "488534"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -42,17 +43,21 @@
    "source": [
     "vehicle_positions_url = \"https://cdn.mbta.com/realtime/VehiclePositions.pb\"\n",
     "trip_updates_url = \"https://cdn.mbta.com/realtime/TripUpdates.pb\"\n",
+    "alert_url = \"https://cdn.mbta.com/realtime/Alerts.pb\"\n",
     "\n",
     "vehicle_positions_response = requests.get(vehicle_positions_url)\n",
     "vehicle_positions.ParseFromString(vehicle_positions_response.content)\n",
     "\n",
     "trip_updates_response = requests.get(trip_updates_url)\n",
-    "trip_updates.ParseFromString(trip_updates_response.content)"
+    "trip_updates.ParseFromString(trip_updates_response.content)\n",
+    "\n",
+    "alert_response = requests.get(alert_url)\n",
+    "alerts.ParseFromString(alert_response.content)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 8,
    "id": "7c35bcbb",
    "metadata": {},
    "outputs": [
@@ -60,59 +65,154 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1778706397 0 2.0\n",
-      "1652\n"
+      "1778856211 0 2.0\n",
+      "111\n"
      ]
     }
    ],
    "source": [
     "print(\n",
-    "    trip_updates.header.timestamp,\n",
-    "    trip_updates.header.incrementality,\n",
-    "    trip_updates.header.gtfs_realtime_version,\n",
+    "    alerts.header.timestamp,\n",
+    "    alerts.header.incrementality,\n",
+    "    alerts.header.gtfs_realtime_version,\n",
     ")\n",
     "\n",
-    "print(len(trip_updates.entity))"
+    "print(len(alerts.entity))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 11,
    "id": "f5ce3955",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "38\n",
-      "True\n",
-      "39\n",
-      "True\n",
-      "40\n",
-      "True\n",
-      "41\n",
-      "True\n",
-      "42\n",
-      "True\n",
-      "43\n",
-      "True\n",
-      "44\n",
-      "True\n"
-     ]
+     "data": {
+      "text/plain": [
+       "active_period {\n",
+       "  start: 1752760920\n",
+       "}\n",
+       "informed_entity {\n",
+       "  agency_id: \"1\"\n",
+       "  route_id: \"CR-Providence\"\n",
+       "  route_type: 2\n",
+       "  stop_id: \"NEC-1851-03\"\n",
+       "}\n",
+       "cause: UNKNOWN_CAUSE\n",
+       "effect: UNKNOWN_EFFECT\n",
+       "url {\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php\"\n",
+       "    language: \"en\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=es-419\"\n",
+       "    language: \"es-419\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=pt-BR\"\n",
+       "    language: \"pt-BR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=fr-FR\"\n",
+       "    language: \"fr-FR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=ht-HT\"\n",
+       "    language: \"ht-HT\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=zh-CN\"\n",
+       "    language: \"zh-CN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=vi-VN\"\n",
+       "    language: \"vi-VN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"https://www.dot.ri.gov/projects/PVDStation/index.php?locale=zh-TW\"\n",
+       "    language: \"zh-TW\"\n",
+       "  }\n",
+       "}\n",
+       "header_text {\n",
+       "  translation {\n",
+       "    text: \"To accommodate Providence Station Renovations, construction barriers have been installed and the Southern stairwell to Track 1 is out of service. Staircase access to Track 3 and Track 5 are now open.\"\n",
+       "    language: \"en\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Para acomodar las renovaciones de la estación de Providence, se instalaron barreras de construcción y la escalera sur hacia la vía 1 está fuera de servicio. El acceso por escalera a las vías 3 y 5 ya está abierto.\"\n",
+       "    language: \"es-419\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Para viabilizar as obras de reforma da Estação Providence, foram instaladas barreiras de construção e a escadaria sul de acesso à Plataforma 1 está fora de serviço. O acesso por escada às pistas 3 e 5 já está aberto.\"\n",
+       "    language: \"pt-BR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Pour les besoins de la rénovation de la Providence Station, des barrières de travaux ont été installées et l\\'escalier sud menant à la voie 1 est hors service. Les escaliers d\\'accès aux pistes 3 et 5 sont désormais ouverts.\"\n",
+       "    language: \"fr-FR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Pou akomode renovasyon Estasyon Providence la, yo enstale baryè konstriksyon epi eskalye Sid ki mennen nan Ray 1 an pa an sèvis. Aksè eskalye pou ale nan Ray 3 ak Ray 5 la louvri kounye a.\"\n",
+       "    language: \"ht-HT\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"为了适应Providence车站的翻新，已经安装了建筑屏障，通往1号轨道的南部楼梯间已暂停服务。通往 3 号和 5 号轨道的楼梯通道现已开放。\"\n",
+       "    language: \"zh-CN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Để phù hợp với việc cải tạo Nhà ga Providence, các rào chắn thi công đã được lắp đặt và cầu thang phía Nam đến Đường ray 1 đã ngừng hoạt động. Lối vào cầu thang đến Đường 3 và Đường 5 hiện đã được mở.\"\n",
+       "    language: \"vi-VN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"為了配合普羅維登斯站的翻新工程，已安裝建築施工屏障，而前往一號軌道的南部樓梯間已暫停服務。通往 3 號軌道和 5 號軌道的樓梯通道現已開放。\"\n",
+       "    language: \"zh-TW\"\n",
+       "  }\n",
+       "}\n",
+       "description_text {\n",
+       "  translation {\n",
+       "    text: \"Affected lines:\\r\\nFoxboro Event Service\\r\\nProvidence/Stoughton Line\"\n",
+       "    language: \"en\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Líneas afectadas:\\nFoxboro Event Service\\nProvidence/Stoughton Line\"\n",
+       "    language: \"es-419\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Linhas afetadas:\\nFoxboro Event Service\\nProvidence/Stoughton Line\"\n",
+       "    language: \"pt-BR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Lignes concernées :\\r\\nFoxboro Event Service\\r\\nProvidence/Stoughton Line\"\n",
+       "    language: \"fr-FR\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Liy ki afekte yo:\\n Foxboro Event Service\\n Providence/Stoughton Line\"\n",
+       "    language: \"ht-HT\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"受影响的线路：\\nFoxboro Event Service\\nProvidence/Stoughton Line\"\n",
+       "    language: \"zh-CN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"Các dòng bị ảnh hưởng:\\nFoxboro Event Service\\nProvidence/Stoughton Line\"\n",
+       "    language: \"vi-VN\"\n",
+       "  }\n",
+       "  translation {\n",
+       "    text: \"受影響的線條：\\nFoxboro Event Service\\nProvidence/Stoughton Line\"\n",
+       "    language: \"zh-TW\"\n",
+       "  }\n",
+       "}\n",
+       "severity_level: INFO"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "entities = trip_updates.entity\n",
-    "\n",
-    "entity = entities[0]\n",
-    "t = entity.trip_update\n",
-    "stop_time_updates = t.stop_time_update\n",
-    "\n",
-    "for stu in stop_time_updates:\n",
-    "    stop_sequence = stu.stop_sequence\n",
-    "    print(stop_sequence)\n",
-    "    print(stu.HasField(\"stop_sequence\"))"
+    "entity = alerts.entity[0]\n",
+    "entity.alert"
    ]
   },
   {


### PR DESCRIPTION
GTFS Schedule and GTFS Realtime entities VehiclePosition, TripUpdates and Alerts can now be imported and saved to the database.

- GTFS Schedule import uses a per-record saving which makes it extremely slow for huge feeds (example: MBTA took 30 minutes)
- GTFS Realtime entities VehiclePosition is flattening all fields, TripUpdates is flattening some (except StopTimeUpdate), and Alerts is not flattening anything (this might require a review).