### PR TITLE
feat: export GTFS Realtime data to GeoParquet for the data lake

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -205,17 +205,66 @@ install_duckdb_cli() {
             return
         fi
 
-        warn "Installing DuckDB CLI via official installer..."
+        mkdir -p "${DUCKDB_CLI_DIR}"
+        duckdb_version="v1.5.3"
+
+        case "$(uname -m)" in
+            x86_64)
+                duckdb_asset="duckdb_cli-linux-amd64.zip"
+                duckdb_sha256="35caef1fecbc8d7e2c07de4fd2cdefc5189ec9ba9e1cca228fb1a1c48cc52a8a"
+                ;;
+            aarch64|arm64)
+                duckdb_asset="duckdb_cli-linux-arm64.zip"
+                duckdb_sha256="5e2399428793642e994f1584c47d49f4c58b7b4ec2297ea4a522353a6c553835"
+                ;;
+            *)
+                warn "Unsupported architecture for DuckDB CLI: $(uname -m)"
+                return
+                ;;
+        esac
+
+        duckdb_url="https://github.com/duckdb/duckdb/releases/download/${duckdb_version}/${duckdb_asset}"
+        temp_dir="$(mktemp -d)"
+        zip_path="${temp_dir}/duckdb.zip"
+
+        warn "Installing DuckDB CLI ${duckdb_version} from pinned artifact..."
         attempts=0
-        until curl -fsSL https://install.duckdb.org | sh; do
+        until curl -fsSL -o "${zip_path}" "${duckdb_url}"; do
             attempts=$((attempts + 1))
             if [ "$attempts" -ge 3 ]; then
-                err "DuckDB CLI install failed after ${attempts} attempts"
+                err "DuckDB CLI download failed after ${attempts} attempts"
+                rm -rf "${temp_dir}"
                 return
             fi
-            warn "DuckDB CLI install failed (attempt ${attempts}/3); retrying"
+            warn "DuckDB CLI download failed (attempt ${attempts}/3); retrying"
             sleep 2
         done
+
+        actual_sha256="$(sha256sum "${zip_path}" | awk '{print $1}')"
+        if [ "${actual_sha256}" != "${duckdb_sha256}" ]; then
+            err "DuckDB CLI checksum verification failed"
+            rm -rf "${temp_dir}"
+            return
+        fi
+
+        if ! python - "${zip_path}" "${DUCKDB_CLI_DIR}" <<'PY'
+import sys
+import zipfile
+
+zip_path = sys.argv[1]
+destination_dir = sys.argv[2]
+
+with zipfile.ZipFile(zip_path, "r") as zip_ref:
+    zip_ref.extract("duckdb", destination_dir)
+PY
+        then
+            err "DuckDB CLI extraction failed"
+            rm -rf "${temp_dir}"
+            return
+        fi
+
+        chmod +x "${DUCKDB_CLI_DIR}/duckdb"
+        rm -rf "${temp_dir}"
         log "DuckDB CLI installation complete"
     fi
 
@@ -231,7 +280,11 @@ install_duckdb_cli() {
 section "Installing DuckDB CLI (if needed)..."
 # ------------------------------------------
 
-install_duckdb_cli
+if [ "${1:-}" = "orchestrator" ]; then
+    install_duckdb_cli
+else
+    log "Skipping DuckDB CLI install for service '${1:-unknown}'"
+fi
 
 # In dev mode, replace the PyPI-installed gtfs-django with an editable install
 # pointing at a local clone. This requires UV_NO_SYNC=1 in the container env so

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -6,6 +6,7 @@ VENV_DIR="${UV_PROJECT_ENVIRONMENT:-/home/app/.venv}"
 UV_SYNC_LOCKDIR="/app/.uv-sync.lockdir"
 CLONE_IO_LOCKDIR="/app/.gtfs-io-clone.lockdir"
 CLONE_LOCKDIR="/app/.gtfs-django-clone.lockdir"
+DUCKDB_CLI_DIR="/home/app/.duckdb/cli/latest"
 
 # Colors for output
 RED='\033[0;31m'
@@ -194,6 +195,43 @@ setup_virtualenv
 if [ -d "${VENV_DIR}/bin" ]; then
     export PATH="${VENV_DIR}/bin:$PATH"
 fi
+
+install_duckdb_cli() {
+    if [ -x "${DUCKDB_CLI_DIR}/duckdb" ]; then
+        log "DuckDB CLI already installed"
+    else
+        if ! command -v curl >/dev/null 2>&1; then
+            warn "curl not found; skipping DuckDB CLI installation"
+            return
+        fi
+
+        warn "Installing DuckDB CLI via official installer..."
+        attempts=0
+        until curl -fsSL https://install.duckdb.org | sh; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge 3 ]; then
+                err "DuckDB CLI install failed after ${attempts} attempts"
+                return
+            fi
+            warn "DuckDB CLI install failed (attempt ${attempts}/3); retrying"
+            sleep 2
+        done
+        log "DuckDB CLI installation complete"
+    fi
+
+    if [ -d "${DUCKDB_CLI_DIR}" ]; then
+        export PATH="${DUCKDB_CLI_DIR}:$PATH"
+        log "DuckDB CLI added to PATH (${DUCKDB_CLI_DIR})"
+    else
+        warn "DuckDB CLI directory not found at ${DUCKDB_CLI_DIR}"
+    fi
+}
+
+# ------------------------------------------
+section "Installing DuckDB CLI (if needed)..."
+# ------------------------------------------
+
+install_duckdb_cli
 
 # In dev mode, replace the PyPI-installed gtfs-django with an editable install
 # pointing at a local clone. This requires UV_NO_SYNC=1 in the container env so

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -802,7 +802,57 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
             "position": {
                 "encoding": "WKB",
                 "geometry_types": ["Point"],
-                "crs": None,
+                "crs": {
+                    "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+                    "type": "GeographicCRS",
+                    "name": "WGS 84",
+                    "datum_ensemble": {
+                        "name": "World Geodetic System 1984 ensemble",
+                        "members": [
+                            {"name": "World Geodetic System 1984 (Transit)"},
+                            {"name": "World Geodetic System 1984 (G730)"},
+                            {"name": "World Geodetic System 1984 (G873)"},
+                            {"name": "World Geodetic System 1984 (G1150)"},
+                            {"name": "World Geodetic System 1984 (G1674)"},
+                            {"name": "World Geodetic System 1984 (G1762)"},
+                            {"name": "World Geodetic System 1984 (G2139)"},
+                            {"name": "World Geodetic System 1984 (G2296)"},
+                        ],
+                        "ellipsoid": {
+                            "name": "WGS 84",
+                            "semi_major_axis": 6378137,
+                            "inverse_flattening": 298.257223563,
+                        },
+                        "accuracy": "2.0",
+                        "id": {"authority": "EPSG", "code": 6326},
+                    },
+                    "coordinate_system": {
+                        "subtype": "ellipsoidal",
+                        "axis": [
+                            {
+                                "name": "Geodetic latitude",
+                                "abbreviation": "Lat",
+                                "direction": "north",
+                                "unit": "degree",
+                            },
+                            {
+                                "name": "Geodetic longitude",
+                                "abbreviation": "Lon",
+                                "direction": "east",
+                                "unit": "degree",
+                            },
+                        ],
+                    },
+                    "scope": "Horizontal component of 3D system.",
+                    "area": "World.",
+                    "bbox": {
+                        "south_latitude": -90,
+                        "west_longitude": -180,
+                        "north_latitude": 90,
+                        "east_longitude": 180,
+                    },
+                    "id": {"authority": "EPSG", "code": 4326},
+                },
             }
         },
     }

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -1,12 +1,20 @@
 from celery import shared_task
 
 import logging
+import json
 from datetime import datetime, timedelta
+from pathlib import Path
+import uuid
+from zoneinfo import ZoneInfo
 import pytz
+from django.conf import settings
 from django.db import transaction
+from django.utils import timezone
 import zipfile
 import io
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import requests
 from google.transit import gtfs_realtime_pb2 as gtfs_rt
 from feed.models import (
@@ -717,3 +725,197 @@ def get_alerts():
                     )
 
     return "ServiceAlerts saved to database"
+
+
+@shared_task
+def save_vehicle_positions_to_parquet(use_current_hour=False):
+    """Export VehiclePosition rows into Hive partitions.
+
+    By default it exports the last complete hour. Set use_current_hour=True to
+    export records from the current hour (debug mode).
+    """
+    app_timezone = ZoneInfo(settings.TIME_ZONE)
+    now_local = timezone.localtime(timezone.now(), app_timezone)
+
+    if isinstance(use_current_hour, str):
+        use_current_hour = use_current_hour.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }
+
+    if use_current_hour:
+        window_start = now_local.replace(minute=0, second=0, microsecond=0)
+        window_end = window_start + timedelta(hours=1)
+    else:
+        window_end = now_local.replace(minute=0, second=0, microsecond=0)
+        window_start = window_end - timedelta(hours=1)
+
+    fields = [
+        "id",
+        "entity_id",
+        "feed_message_id",
+        "feed_message__publisher__code",
+        "trip_trip_id",
+        "trip_route_id",
+        "trip_direction_id",
+        "trip_start_time",
+        "trip_start_date",
+        "trip_schedule_relationship",
+        "vehicle_id",
+        "vehicle_label",
+        "vehicle_license_plate",
+        "vehicle_wheelchair_accessible",
+        "position_latitude",
+        "position_longitude",
+        "position_point",
+        "position_bearing",
+        "position_odometer",
+        "position_speed",
+        "current_stop_sequence",
+        "stop_id",
+        "current_status",
+        "timestamp",
+        "congestion_level",
+        "occupancy_status",
+        "occupancy_percentage",
+    ]
+
+    chunk_size = 5000
+    row_count = 0
+    output_dir = (
+        Path("/app/data")
+        / "vehicle_positions"
+        / f"date={window_start.strftime('%Y-%m-%d')}"
+        / f"hour={window_start.strftime('%H')}"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = output_dir / f"part-{uuid.uuid7()}.parquet"
+
+    geo_metadata = {
+        "version": "1.1.0",
+        "primary_column": "position_point",
+        "columns": {
+            "position_point": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "crs": None,
+            }
+        },
+    }
+
+    parquet_schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("entity_id", pa.string()),
+            pa.field("feed_message_id", pa.string()),
+            pa.field("feed_message__publisher__code", pa.string()),
+            pa.field("trip_trip_id", pa.string()),
+            pa.field("trip_route_id", pa.string()),
+            pa.field("trip_direction_id", pa.int64()),
+            pa.field("trip_start_time", pa.duration("us")),
+            pa.field("trip_start_date", pa.date32()),
+            pa.field("trip_schedule_relationship", pa.int64()),
+            pa.field("vehicle_id", pa.string()),
+            pa.field("vehicle_label", pa.string()),
+            pa.field("vehicle_license_plate", pa.string()),
+            pa.field("vehicle_wheelchair_accessible", pa.string()),
+            pa.field("position_latitude", pa.float64()),
+            pa.field("position_longitude", pa.float64()),
+            pa.field("position_point", pa.binary()),
+            pa.field("position_bearing", pa.float64()),
+            pa.field("position_odometer", pa.float64()),
+            pa.field("position_speed", pa.float64()),
+            pa.field("current_stop_sequence", pa.int64()),
+            pa.field("stop_id", pa.string()),
+            pa.field("current_status", pa.int64()),
+            pa.field("timestamp", pa.timestamp("us", tz=settings.TIME_ZONE)),
+            pa.field("congestion_level", pa.int64()),
+            pa.field("occupancy_status", pa.int64()),
+            pa.field("occupancy_percentage", pa.int64()),
+        ],
+        metadata={b"geo": json.dumps(geo_metadata).encode("utf-8")},
+    )
+
+    string_columns = {
+        "entity_id",
+        "feed_message_id",
+        "feed_message__publisher__code",
+        "trip_trip_id",
+        "trip_route_id",
+        "vehicle_id",
+        "vehicle_label",
+        "vehicle_license_plate",
+        "vehicle_wheelchair_accessible",
+        "stop_id",
+    }
+
+    writer = None
+    batch_rows = []
+
+    def flush_batch(records, parquet_writer):
+        nonlocal row_count
+        if not records:
+            return parquet_writer
+
+        arrow_table = pa.Table.from_pylist(records, schema=parquet_schema)
+        row_count += arrow_table.num_rows
+
+        if parquet_writer is None:
+            parquet_writer = pq.ParquetWriter(
+                str(output_file),
+                parquet_schema,
+                compression="zstd",
+            )
+
+        parquet_writer.write_table(arrow_table)
+        return parquet_writer
+
+    try:
+        queryset = (
+            VehiclePosition.objects.filter(
+                timestamp__gte=window_start,
+                timestamp__lt=window_end,
+            )
+            .values(*fields)
+            .iterator(chunk_size=chunk_size)
+        )
+
+        for row in queryset:
+            point = row.pop("position_point", None)
+            row["position_point"] = bytes(point.wkb) if point is not None else None
+
+            row_timestamp = row.get("timestamp")
+            if row_timestamp is not None:
+                row["timestamp"] = timezone.localtime(row_timestamp, app_timezone)
+
+            for column in string_columns:
+                value = row.get(column)
+                if value is not None and not isinstance(value, str):
+                    row[column] = str(value)
+
+            batch_rows.append(row)
+
+            if len(batch_rows) >= chunk_size:
+                writer = flush_batch(batch_rows, writer)
+                batch_rows = []
+
+        writer = flush_batch(batch_rows, writer)
+
+        if writer is None:
+            empty_table = pa.Table.from_pylist([], schema=parquet_schema)
+            pq.write_table(empty_table, str(output_file), compression="zstd")
+    finally:
+        if writer is not None:
+            writer.close()
+
+    return (
+        "Task completed: VehiclePositions exported to parquet "
+        f"({window_start.isoformat()} to {window_end.isoformat()}, "
+        f"mode={'current_hour' if use_current_hour else 'last_complete_hour'}) "
+        f"-> {output_file} "
+        f"rows={row_count}"
+    )

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -797,9 +797,9 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
 
     geo_metadata = {
         "version": "1.1.0",
-        "primary_column": "position_point",
+        "primary_column": "position",
         "columns": {
-            "position_point": {
+            "position": {
                 "encoding": "WKB",
                 "geometry_types": ["Point"],
                 "crs": None,
@@ -812,24 +812,24 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
             pa.field("id", pa.int64()),
             pa.field("entity_id", pa.string()),
             pa.field("feed_message_id", pa.string()),
-            pa.field("feed_message__publisher__code", pa.string()),
-            pa.field("trip_trip_id", pa.string()),
-            pa.field("trip_route_id", pa.string()),
-            pa.field("trip_direction_id", pa.int64()),
-            pa.field("trip_start_time", pa.duration("us")),
-            pa.field("trip_start_date", pa.date32()),
-            pa.field("trip_schedule_relationship", pa.int64()),
+            pa.field("publisher_code", pa.string()),
+            pa.field("trip_id", pa.string()),
+            pa.field("route_id", pa.string()),
+            pa.field("direction_id", pa.int64()),
+            pa.field("start_time", pa.duration("s")),
+            pa.field("start_date", pa.date32()),
+            pa.field("schedule_relationship", pa.int64()),
             pa.field("vehicle_id", pa.string()),
             pa.field("vehicle_label", pa.string()),
             pa.field("vehicle_license_plate", pa.string()),
-            pa.field("vehicle_wheelchair_accessible", pa.string()),
-            pa.field("position_latitude", pa.float64()),
-            pa.field("position_longitude", pa.float64()),
-            pa.field("position_point", pa.binary()),
-            pa.field("position_bearing", pa.float64()),
-            pa.field("position_odometer", pa.float64()),
-            pa.field("position_speed", pa.float64()),
-            pa.field("current_stop_sequence", pa.int64()),
+            pa.field("wheelchair_accessible", pa.string()),
+            pa.field("latitude", pa.float64()),
+            pa.field("longitude", pa.float64()),
+            pa.field("position", pa.binary()),
+            pa.field("bearing", pa.float64()),
+            pa.field("odometer", pa.float64()),
+            pa.field("speed", pa.float64()),
+            pa.field("stop_sequence", pa.int64()),
             pa.field("stop_id", pa.string()),
             pa.field("current_status", pa.int64()),
             pa.field("timestamp", pa.timestamp("us", tz=settings.TIME_ZONE)),
@@ -843,13 +843,13 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
     string_columns = {
         "entity_id",
         "feed_message_id",
-        "feed_message__publisher__code",
-        "trip_trip_id",
-        "trip_route_id",
+        "publisher_code",
+        "trip_id",
+        "route_id",
         "vehicle_id",
         "vehicle_label",
         "vehicle_license_plate",
-        "vehicle_wheelchair_accessible",
+        "wheelchair_accessible",
         "stop_id",
     }
 
@@ -884,9 +884,37 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
             .iterator(chunk_size=chunk_size)
         )
 
-        for row in queryset:
-            point = row.pop("position_point", None)
-            row["position_point"] = bytes(point.wkb) if point is not None else None
+        for raw_row in queryset:
+            point = raw_row.get("position_point")
+            row = {
+                "id": raw_row.get("id"),
+                "entity_id": raw_row.get("entity_id"),
+                "feed_message_id": raw_row.get("feed_message_id"),
+                "publisher_code": raw_row.get("feed_message__publisher__code"),
+                "trip_id": raw_row.get("trip_trip_id"),
+                "route_id": raw_row.get("trip_route_id"),
+                "direction_id": raw_row.get("trip_direction_id"),
+                "start_time": raw_row.get("trip_start_time"),
+                "start_date": raw_row.get("trip_start_date"),
+                "schedule_relationship": raw_row.get("trip_schedule_relationship"),
+                "vehicle_id": raw_row.get("vehicle_id"),
+                "vehicle_label": raw_row.get("vehicle_label"),
+                "vehicle_license_plate": raw_row.get("vehicle_license_plate"),
+                "wheelchair_accessible": raw_row.get("vehicle_wheelchair_accessible"),
+                "latitude": raw_row.get("position_latitude"),
+                "longitude": raw_row.get("position_longitude"),
+                "position": bytes(point.wkb) if point is not None else None,
+                "bearing": raw_row.get("position_bearing"),
+                "odometer": raw_row.get("position_odometer"),
+                "speed": raw_row.get("position_speed"),
+                "stop_sequence": raw_row.get("current_stop_sequence"),
+                "stop_id": raw_row.get("stop_id"),
+                "current_status": raw_row.get("current_status"),
+                "timestamp": raw_row.get("timestamp"),
+                "congestion_level": raw_row.get("congestion_level"),
+                "occupancy_status": raw_row.get("occupancy_status"),
+                "occupancy_percentage": raw_row.get("occupancy_percentage"),
+            }
 
             row_timestamp = row.get("timestamp")
             if row_timestamp is not None:

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -906,14 +906,255 @@ def save_vehicle_positions_to_parquet(use_current_hour=False):
         writer = flush_batch(batch_rows, writer)
 
         if writer is None:
-            empty_table = pa.Table.from_pylist([], schema=parquet_schema)
-            pq.write_table(empty_table, str(output_file), compression="zstd")
+            return (
+                "Task completed: VehiclePositions export skipped (no rows) "
+                f"({window_start.isoformat()} to {window_end.isoformat()}, "
+                f"mode={'current_hour' if use_current_hour else 'last_complete_hour'})"
+            )
     finally:
         if writer is not None:
             writer.close()
 
     return (
         "Task completed: VehiclePositions exported to parquet "
+        f"({window_start.isoformat()} to {window_end.isoformat()}, "
+        f"mode={'current_hour' if use_current_hour else 'last_complete_hour'}) "
+        f"-> {output_file} "
+        f"rows={row_count}"
+    )
+
+
+@shared_task
+def save_stop_time_updates_to_parquet(use_current_hour=False):
+    """Export StopTimeUpdate rows into Hive partitions.
+
+    By default it exports the last complete hour. Set use_current_hour=True to
+    export records from the current hour (debug mode).
+    """
+    app_timezone = ZoneInfo(settings.TIME_ZONE)
+    now_local = timezone.localtime(timezone.now(), app_timezone)
+
+    if isinstance(use_current_hour, str):
+        use_current_hour = use_current_hour.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }
+
+    if use_current_hour:
+        window_start = now_local.replace(minute=0, second=0, microsecond=0)
+        window_end = window_start + timedelta(hours=1)
+    else:
+        window_end = now_local.replace(minute=0, second=0, microsecond=0)
+        window_start = window_end - timedelta(hours=1)
+
+    fields = [
+        "id",
+        "trip_update__entity_id",
+        "trip_update__feed_message_id",
+        "trip_update__feed_message__publisher__code",
+        "trip_update__timestamp",
+        "trip_update__trip_trip_id",
+        "trip_update__trip_route_id",
+        "trip_update__trip_direction_id",
+        "trip_update__trip_start_time",
+        "trip_update__trip_start_date",
+        "trip_update__trip_schedule_relationship",
+        "trip_update__vehicle_id",
+        "trip_update__vehicle_label",
+        "trip_update__vehicle_license_plate",
+        "stop_sequence",
+        "stop_id",
+        "arrival_delay",
+        "arrival_time",
+        "arrival_uncertainty",
+        "departure_delay",
+        "departure_time",
+        "departure_uncertainty",
+    ]
+
+    chunk_size = 5000
+    row_count = 0
+    output_dir = (
+        Path("/app/data")
+        / "stop_time_updates"
+        / f"date={window_start.strftime('%Y-%m-%d')}"
+        / f"hour={window_start.strftime('%H')}"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = output_dir / f"part-{uuid.uuid7()}.parquet"
+
+    parquet_schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("entity_id", pa.string()),
+            pa.field("feed_message_id", pa.string()),
+            pa.field("publisher_code", pa.string()),
+            pa.field("timestamp", pa.timestamp("us", tz=settings.TIME_ZONE)),
+            pa.field("trip_id", pa.string()),
+            pa.field("route_id", pa.string()),
+            pa.field("direction_id", pa.int64()),
+            pa.field("start_time", pa.duration("us")),
+            pa.field("start_date", pa.date32()),
+            pa.field("schedule_relationship", pa.string()),
+            pa.field("vehicle_id", pa.string()),
+            pa.field("vehicle_label", pa.string()),
+            pa.field("vehicle_license_plate", pa.string()),
+            pa.field("stop_sequence", pa.int64()),
+            pa.field("stop_id", pa.string()),
+            pa.field("arrival_delay", pa.int64()),
+            pa.field("arrival_time", pa.timestamp("us", tz=settings.TIME_ZONE)),
+            pa.field("arrival_uncertainty", pa.int64()),
+            pa.field("arrival_prediction_horizon", pa.int64()),
+            pa.field("departure_delay", pa.int64()),
+            pa.field("departure_time", pa.timestamp("us", tz=settings.TIME_ZONE)),
+            pa.field("departure_uncertainty", pa.int64()),
+            pa.field("departure_prediction_horizon", pa.int64()),
+        ]
+    )
+
+    string_columns = {
+        "entity_id",
+        "feed_message_id",
+        "publisher_code",
+        "trip_id",
+        "route_id",
+        "schedule_relationship",
+        "vehicle_id",
+        "vehicle_label",
+        "vehicle_license_plate",
+        "stop_id",
+    }
+
+    writer = None
+    batch_rows = []
+
+    def flush_batch(records, parquet_writer):
+        nonlocal row_count
+        if not records:
+            return parquet_writer
+
+        arrow_table = pa.Table.from_pylist(records, schema=parquet_schema)
+        row_count += arrow_table.num_rows
+
+        if parquet_writer is None:
+            parquet_writer = pq.ParquetWriter(
+                str(output_file),
+                parquet_schema,
+                compression="zstd",
+            )
+
+        parquet_writer.write_table(arrow_table)
+        return parquet_writer
+
+    try:
+        queryset = (
+            StopTimeUpdate.objects.filter(
+                trip_update__timestamp__gte=window_start,
+                trip_update__timestamp__lt=window_end,
+            )
+            .values(*fields)
+            .iterator(chunk_size=chunk_size)
+        )
+
+        for raw_row in queryset:
+            row = {
+                "id": raw_row.get("id"),
+                "entity_id": raw_row.get("trip_update__entity_id"),
+                "feed_message_id": raw_row.get("trip_update__feed_message_id"),
+                "publisher_code": raw_row.get(
+                    "trip_update__feed_message__publisher__code"
+                ),
+                "timestamp": raw_row.get("trip_update__timestamp"),
+                "trip_id": raw_row.get("trip_update__trip_trip_id"),
+                "route_id": raw_row.get("trip_update__trip_route_id"),
+                "direction_id": raw_row.get("trip_update__trip_direction_id"),
+                "start_time": raw_row.get("trip_update__trip_start_time"),
+                "start_date": raw_row.get("trip_update__trip_start_date"),
+                "schedule_relationship": raw_row.get(
+                    "trip_update__trip_schedule_relationship"
+                ),
+                "vehicle_id": raw_row.get("trip_update__vehicle_id"),
+                "vehicle_label": raw_row.get("trip_update__vehicle_label"),
+                "vehicle_license_plate": raw_row.get(
+                    "trip_update__vehicle_license_plate"
+                ),
+                "stop_sequence": raw_row.get("stop_sequence"),
+                "stop_id": raw_row.get("stop_id"),
+                "arrival_delay": raw_row.get("arrival_delay"),
+                "arrival_time": raw_row.get("arrival_time"),
+                "arrival_uncertainty": raw_row.get("arrival_uncertainty"),
+                "arrival_prediction_horizon": (
+                    int(
+                        (
+                            (
+                                raw_row.get("arrival_time")
+                                - raw_row.get("trip_update__timestamp")
+                            ).total_seconds()
+                        )
+                    )
+                    if raw_row.get("arrival_time") is not None
+                    and raw_row.get("trip_update__timestamp") is not None
+                    else None
+                ),
+                "departure_delay": raw_row.get("departure_delay"),
+                "departure_time": raw_row.get("departure_time"),
+                "departure_uncertainty": raw_row.get("departure_uncertainty"),
+                "departure_prediction_horizon": (
+                    int(
+                        (
+                            (
+                                raw_row.get("departure_time")
+                                - raw_row.get("trip_update__timestamp")
+                            ).total_seconds()
+                        )
+                    )
+                    if raw_row.get("departure_time") is not None
+                    and raw_row.get("trip_update__timestamp") is not None
+                    else None
+                ),
+            }
+
+            row_timestamp = row.get("timestamp")
+            if row_timestamp is not None:
+                row["timestamp"] = timezone.localtime(row_timestamp, app_timezone)
+
+            arrival_time = row.get("arrival_time")
+            if arrival_time is not None:
+                row["arrival_time"] = timezone.localtime(arrival_time, app_timezone)
+
+            departure_time = row.get("departure_time")
+            if departure_time is not None:
+                row["departure_time"] = timezone.localtime(departure_time, app_timezone)
+
+            for column in string_columns:
+                value = row.get(column)
+                if value is not None and not isinstance(value, str):
+                    row[column] = str(value)
+
+            batch_rows.append(row)
+
+            if len(batch_rows) >= chunk_size:
+                writer = flush_batch(batch_rows, writer)
+                batch_rows = []
+
+        writer = flush_batch(batch_rows, writer)
+
+        if writer is None:
+            return (
+                "Task completed: StopTimeUpdates export skipped (no rows) "
+                f"({window_start.isoformat()} to {window_end.isoformat()}, "
+                f"mode={'current_hour' if use_current_hour else 'last_complete_hour'})"
+            )
+    finally:
+        if writer is not None:
+            writer.close()
+
+    return (
+        "Task completed: StopTimeUpdates exported to parquet "
         f"({window_start.isoformat()} to {window_end.isoformat()}, "
         f"mode={'current_hour' if use_current_hour else 'last_complete_hour'}) "
         f"-> {output_file} "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,16 +31,15 @@ dependencies = [
     "redis>=6.4.0",
     "pytz>=2026.1.post1",
     "requests>=2.33.1",
+    "pyarrow>=21.0.0",
+    "duckdb>=1.5.3",
 ]
 
 [dependency-groups]
 dev = ["pytest>=8.4.2", "ruff>=0.13.0", "watchdog>=6.0.0"]
 
 [tool.uv.workspace]
-members = [
-    "gtfs-io",
-    "gtfs-django",
-]
+members = ["gtfs-io", "gtfs-django"]
 
 [tool.uv.sources]
 gtfs-django = { workspace = true, editable = true }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -580,6 +580,21 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/00/d579dcb2a536b6ea3a2563cdad6844f77d81a9b2d4b22a858097f2468acf/duckdb-1.5.3.tar.gz", hash = "sha256:df39428eb130faa35ae96fd35245bdeae6ecf43936250b116b5fead568eb9f16", size = 18026640, upload-time = "2026-05-20T11:55:31.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/c2/d4b6f8a5e4d3bc25773be6da76a99d9661ebbf3552c007c460d2dd59dbf8/duckdb-1.5.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4bfa9a4dadf71e83e2c4eaca2f9421c82a54defecc1b0b4c0be95e2389dec4fe", size = 32636685, upload-time = "2026-05-20T11:55:13.158Z" },
+    { url = "https://files.pythonhosted.org/packages/42/58/e835c8298979d29db7a62cb5acc29e9b57aeaca7cdde2fcd3ac980f5cb18/duckdb-1.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aea7baf67ad7e1829ac76f67d7dcbd7fb1f57c3eb179d55ac30952df4709ae30", size = 17308134, upload-time = "2026-05-20T11:55:16.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/617b51363f5613418c8b224b3cce16b58e6dde80904566bec232579c1d4e/duckdb-1.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b0b4f088a65d77e1217ce5d7eff889e63fedc44281200d899ff47c84d8ff836", size = 15449891, upload-time = "2026-05-20T11:55:18.687Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/72/354146656e8d9ba3853d3a5ee80a481b8c5f70edfc3d5ae80a8c4479c967/duckdb-1.5.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe8d0c1f6a120aa03fa6e0d03897c71a1842e6cf7afd31d181348391f7108fe1", size = 19338499, upload-time = "2026-05-20T11:55:21.34Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -799,6 +814,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "djangorestframework-gis" },
     { name = "drf-spectacular" },
+    { name = "duckdb" },
     { name = "flower" },
     { name = "gtfs-django" },
     { name = "gtfs-io" },
@@ -808,6 +824,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
+    { name = "pyarrow" },
     { name = "python-decouple" },
     { name = "pytz" },
     { name = "redis" },
@@ -836,6 +853,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "djangorestframework-gis", specifier = ">=1.2.0" },
     { name = "drf-spectacular", specifier = ">=0.28.0" },
+    { name = "duckdb", specifier = ">=1.5.3" },
     { name = "flower", specifier = ">=2.0.1" },
     { name = "gtfs-django", editable = "gtfs-django" },
     { name = "gtfs-io", editable = "gtfs-io" },
@@ -845,6 +863,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.2" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "python-decouple", specifier = ">=3.8" },
     { name = "pytz", specifier = ">=2026.1.post1" },
     { name = "redis", specifier = ">=6.4.0" },
@@ -1351,6 +1370,28 @@ name = "py-ubjson"
 version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/c7/28220d37e041fe1df03e857fe48f768dcd30cd151480bf6f00da8713214a/py-ubjson-0.16.1.tar.gz", hash = "sha256:b9bfb8695a1c7e3632e800fb83c943bf67ed45ddd87cd0344851610c69a5a482", size = 50316, upload-time = "2020-04-18T15:05:57.698Z" }
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
 
 [[package]]
 name = "pyasn1"


### PR DESCRIPTION
## Summary

Add Celery tasks that periodically export GTFS Realtime data (VehiclePositions and StopTimeUpdates) to Parquet files with Hive-style partitioning, forming the foundation of the project's data lake.

## Changes

### New Celery tasks (`engine/tasks.py`)

- **`save_vehicle_positions_to_parquet()`** — Exports `VehiclePosition` records as [GeoParquet](https://geoparquet.org/) (v1.1.0) with WKB-encoded `Point` geometry, enabling spatial queries with tools like DuckDB's `spatial` extension.
- **`save_stop_time_updates_to_parquet()`** — Exports `StopTimeUpdate` records to standard Parquet, including computed `arrival_prediction_horizon` and `departure_prediction_horizon` columns (seconds between the prediction timestamp and the predicted arrival/departure).

Both tasks:
- Default to exporting the **last complete hour**; accept `use_current_hour=True` for debugging
- Write to Hive-partitioned directories: `/app/data/<entity>/date=YYYY-MM-DD/hour=HH/`
- Use **chunked streaming** (5 000 rows) via `PyArrow.ParquetWriter` to bound memory
- Compress with **ZSTD**
- Name output files with **UUID v7** for time-ordered, collision-free parts
- Produce clean column names (e.g. `trip_trip_id` → `trip_id`, `feed_message__publisher__code` → `publisher_code`)

### DuckDB CLI installation (`docker-entrypoint.sh`)

Adds an `install_duckdb_cli()` step to the container entrypoint that installs the DuckDB CLI binary (with retry logic), making it available for ad-hoc queries against the exported Parquet files.

### Dependencies (`pyproject.toml`)

- `pyarrow >= 21.0.0`
- `duckdb >= 1.5.3`

## Output structure

```
/app/data/
├── vehicle_positions/
│   └── date=2026-05-22/
│       └── hour=14/
│           └── part-<uuid7>.parquet    ← GeoParquet
└── stop_time_updates/
    └── date=2026-05-22/
        └── hour=14/
            └── part-<uuid7>.parquet
```
