### PR TITLE
feature: add stop/route topics, lifecycle hardening, and testing website

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -157,6 +157,8 @@ explicit `CANCELED` or `DELETED` relationships.
 | `RUN_EXPECTED_END_GRACE_SECONDS`     |     900 | Grace after expected end before terminal classification.  |
 | `RUN_UNKNOWN_TIMEOUT_SECONDS`        |    1800 | Silence before interrupting a run with no expected end.   |
 | `RUN_TERMINAL_STATE_TTL_SECONDS`     |   86400 | Retention of terminal Redis state.                        |
+| `RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS` | 120 | Renewable TTL preventing overlapping lifecycle evaluations. |
+| `GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS` | 120 | Past-time tolerance for public stop prediction snapshots. |
 
 `No Signal` is nonterminal and remains active. Reappearance publishes
 `RunSignalRestored`. Terminal transitions persist `ended_at` and

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -25,7 +25,10 @@ from runs.services.lifecycle import (
     r as lifecycle_redis,
     record_successful_poll,
 )
-from updates.refresh import refresh_active_stop_time_update_topics
+from updates.refresh import (
+    refresh_active_stop_time_update_topics,
+    refresh_active_vehicle_position_topics,
+)
 
 logging.basicConfig(
     format="%(levelname)s: %(message)s",
@@ -70,6 +73,7 @@ def get_vehicle_positions() -> str:
             "Please add at least one active transit system to fetch vehicle positions."
         )
         return "No active transit systems found."
+    successfully_polled_systems: set[str] = set()
     for transit_system in transit_systems:
         feed_publishers = FeedPublisher.objects.filter(
             transit_system=transit_system, is_active=True
@@ -103,6 +107,16 @@ def get_vehicle_positions() -> str:
                 feed_publisher,
                 "vehicle_positions",
                 observed_run_ids,
+            )
+            successfully_polled_systems.add(transit_system.code)
+
+    for transit_system_code in sorted(successfully_polled_systems):
+        try:
+            refresh_active_vehicle_position_topics(transit_system_code)
+        except Exception:
+            logging.exception(
+                "Failed to refresh active VehiclePositions topics for %s",
+                transit_system_code,
             )
 
     return "VehiclePositions have been processed"

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -20,6 +20,7 @@ from runs.services.state import (
     update_trip_updates_state,
 )
 from runs.services.lifecycle import evaluate_active_runs, record_successful_poll
+from updates.refresh import refresh_active_stop_time_update_topics
 
 logging.basicConfig(
     format="%(levelname)s: %(message)s",
@@ -112,6 +113,7 @@ def get_trip_updates() -> str:
             "Please add at least one active transit system to fetch trip updates."
         )
         return "No active transit systems found."
+    successfully_polled_systems: set[str] = set()
     for transit_system in transit_systems:
         feed_publishers = FeedPublisher.objects.filter(
             transit_system=transit_system, is_active=True
@@ -144,6 +146,16 @@ def get_trip_updates() -> str:
                 feed_publisher,
                 "trip_updates",
                 observed_run_ids,
+            )
+            successfully_polled_systems.add(transit_system.code)
+
+    for transit_system_code in sorted(successfully_polled_systems):
+        try:
+            refresh_active_stop_time_update_topics(transit_system_code)
+        except Exception:
+            logging.exception(
+                "Failed to refresh active StopTimeUpdates topics for %s",
+                transit_system_code,
             )
 
     return "TripUpdates have been processed"

--- a/backend/engine/tasks.py
+++ b/backend/engine/tasks.py
@@ -3,6 +3,7 @@ import logging
 from typing import TypedDict
 
 import requests
+from django.conf import settings
 from google.transit import gtfs_realtime_pb2 as gtfs_rt
 from feed.models import TransitSystem, FeedPublisher
 from feed.services.schedule import save_schedule_to_database
@@ -19,7 +20,11 @@ from runs.services.state import (
     update_vehicle_positions_state,
     update_trip_updates_state,
 )
-from runs.services.lifecycle import evaluate_active_runs, record_successful_poll
+from runs.services.lifecycle import (
+    evaluate_active_runs,
+    r as lifecycle_redis,
+    record_successful_poll,
+)
 from updates.refresh import refresh_active_stop_time_update_topics
 
 logging.basicConfig(
@@ -207,7 +212,18 @@ def update_gtfs_realtime() -> str:
 @shared_task
 def evaluate_run_lifecycles() -> dict[str, int]:
     """Classify active runs using feed health, silence, and terminal evidence."""
-    return evaluate_active_runs()
+    lock = lifecycle_redis.lock(
+        "runs:lifecycle:evaluation_lock",
+        timeout=settings.RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS,
+        blocking_timeout=0,
+    )
+    if not lock.acquire(blocking=False):
+        logging.info("Skipping overlapping run lifecycle evaluation.")
+        return {}
+    try:
+        return evaluate_active_runs(heartbeat=lock.reacquire)
+    finally:
+        lock.release()
 
 
 @shared_task

--- a/backend/engine/tests.py
+++ b/backend/engine/tests.py
@@ -1,3 +1,32 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import SimpleTestCase, override_settings
+
+from engine.tasks import evaluate_run_lifecycles
+
+
+@override_settings(RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS=120)
+class EvaluateRunLifecyclesTaskTests(SimpleTestCase):
+    @patch("engine.tasks.evaluate_active_runs")
+    @patch("engine.tasks.lifecycle_redis")
+    def test_skips_overlapping_evaluation(self, redis, evaluate_active_runs):
+        lock = redis.lock.return_value
+        lock.acquire.return_value = False
+
+        result = evaluate_run_lifecycles()
+
+        self.assertEqual(result, {})
+        evaluate_active_runs.assert_not_called()
+        lock.release.assert_not_called()
+
+    @patch("engine.tasks.evaluate_active_runs", return_value={"Completed": 2})
+    @patch("engine.tasks.lifecycle_redis")
+    def test_renews_and_releases_evaluation_lock(self, redis, evaluate_active_runs):
+        lock = redis.lock.return_value
+        lock.acquire.return_value = True
+
+        result = evaluate_run_lifecycles()
+
+        self.assertEqual(result, {"Completed": 2})
+        evaluate_active_runs.assert_called_once_with(heartbeat=lock.reacquire)
+        lock.release.assert_called_once_with()

--- a/backend/engine/tests.py
+++ b/backend/engine/tests.py
@@ -1,8 +1,11 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import requests
 
 from django.test import SimpleTestCase, override_settings
 
-from engine.tasks import evaluate_run_lifecycles
+from engine.tasks import evaluate_run_lifecycles, get_vehicle_positions
 
 
 @override_settings(RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS=120)
@@ -30,3 +33,123 @@ class EvaluateRunLifecyclesTaskTests(SimpleTestCase):
         self.assertEqual(result, {"Completed": 2})
         evaluate_active_runs.assert_called_once_with(heartbeat=lock.reacquire)
         lock.release.assert_called_once_with()
+
+
+class GetVehiclePositionsTaskTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.transit_system_filter = self._start_patch(
+            "engine.tasks.TransitSystem.objects.filter"
+        )
+        self.feed_publisher_filter = self._start_patch(
+            "engine.tasks.FeedPublisher.objects.filter"
+        )
+        self.requests_get = self._start_patch("engine.tasks.requests.get")
+        self.feed_message = self._start_patch("engine.tasks.gtfs_rt.FeedMessage")
+        self.save_vehicle_positions = self._start_patch(
+            "engine.tasks.save_vehicle_positions_to_database"
+        )
+        self.update_vehicle_positions_state = self._start_patch(
+            "engine.tasks.update_vehicle_positions_state"
+        )
+        self.record_successful_poll = self._start_patch(
+            "engine.tasks.record_successful_poll"
+        )
+        self.refresh_topics = self._start_patch(
+            "engine.tasks.refresh_active_vehicle_position_topics"
+        )
+        self.requests_get.return_value.content = b""
+        self.update_vehicle_positions_state.return_value = set()
+
+    def _start_patch(self, target):
+        patcher = patch(target)
+        mocked = patcher.start()
+        self.addCleanup(patcher.stop)
+        return mocked
+
+    @staticmethod
+    def _queryset(items):
+        queryset = MagicMock()
+        queryset.exists.return_value = bool(items)
+        queryset.__iter__.return_value = iter(items)
+        return queryset
+
+    def _configure_systems(self, *systems_and_publishers):
+        transit_systems = []
+        publisher_querysets = []
+        for code, publisher_urls in systems_and_publishers:
+            transit_systems.append(SimpleNamespace(code=code))
+            publishers = [
+                SimpleNamespace(vehicle_positions_url=url)
+                for url in publisher_urls
+            ]
+            publisher_querysets.append(self._queryset(publishers))
+
+        self.transit_system_filter.return_value = self._queryset(transit_systems)
+        self.feed_publisher_filter.side_effect = publisher_querysets
+
+    def test_vehicle_position_poll_refreshes_each_successful_system_once(self):
+        self._configure_systems(
+            ("system-a", ("https://first.example", "https://second.example"))
+        )
+
+        get_vehicle_positions()
+
+        self.refresh_topics.assert_called_once_with("system-a")
+
+    def test_vehicle_position_poll_refreshes_each_system_separately(self):
+        self._configure_systems(
+            ("zeta", ("https://zeta.example",)),
+            ("alpha", ("https://alpha.example",)),
+        )
+
+        get_vehicle_positions()
+
+        self.refresh_topics.assert_has_calls([call("alpha"), call("zeta")])
+        self.assertEqual(self.refresh_topics.call_count, 2)
+
+    def test_vehicle_position_poll_does_not_refresh_failed_publisher(self):
+        self._configure_systems(("system-a", ("https://failed.example",)))
+        self.requests_get.side_effect = requests.RequestException("request failed")
+
+        get_vehicle_positions()
+
+        self.refresh_topics.assert_not_called()
+        self.record_successful_poll.assert_not_called()
+
+    def test_vehicle_position_poll_refreshes_system_with_one_failed_publisher(self):
+        self._configure_systems(
+            ("system-a", ("https://failed.example", "https://success.example"))
+        )
+        successful_response = MagicMock()
+        successful_response.content = b""
+        self.requests_get.side_effect = [
+            requests.RequestException("request failed"),
+            successful_response,
+        ]
+
+        get_vehicle_positions()
+
+        self.refresh_topics.assert_called_once_with("system-a")
+        self.record_successful_poll.assert_called_once()
+
+    def test_vehicle_position_refresh_failure_does_not_fail_task(self):
+        self._configure_systems(("system-a", ("https://success.example",)))
+        self.refresh_topics.side_effect = RuntimeError("refresh failed")
+
+        with patch("engine.tasks.logging.exception") as logging_exception:
+            result = get_vehicle_positions()
+
+        self.assertEqual(result, "VehiclePositions have been processed")
+        logging_exception.assert_called_once_with(
+            "Failed to refresh active VehiclePositions topics for %s",
+            "system-a",
+        )
+
+    def test_vehicle_position_poll_without_active_systems_does_not_refresh(self):
+        self._configure_systems()
+
+        result = get_vehicle_positions()
+
+        self.assertEqual(result, "No active transit systems found.")
+        self.refresh_topics.assert_not_called()

--- a/backend/infobus/settings.py
+++ b/backend/infobus/settings.py
@@ -165,6 +165,13 @@ GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS = config(
     "GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS", default=120, cast=int
 )
 
+# Match the lifecycle signal grace while allowing one delayed vehicle-position poll.
+GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS = config(
+    "GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS",
+    default=120,
+    cast=int,
+)
+
 # Celery settings
 
 CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"

--- a/backend/infobus/settings.py
+++ b/backend/infobus/settings.py
@@ -155,6 +155,15 @@ RUN_UNKNOWN_TIMEOUT_SECONDS = config(
 RUN_TERMINAL_STATE_TTL_SECONDS = config(
     "RUN_TERMINAL_STATE_TTL_SECONDS", default=86400, cast=int
 )
+RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS = config(
+    "RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS", default=120, cast=int
+)
+
+# Match the lifecycle signal grace: one delayed poll or a vehicle dwelling at a
+# stop should not make an otherwise current public prediction disappear.
+GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS = config(
+    "GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS", default=120, cast=int
+)
 
 # Celery settings
 

--- a/backend/runs/README.md
+++ b/backend/runs/README.md
@@ -706,7 +706,8 @@ current defaults are:
 | `RUN_TERMINAL_SILENCE_GRACE_SECONDS` | 120 | Silence after stopping at terminal before completion. |
 | `RUN_EXPECTED_END_GRACE_SECONDS` | 900 | Grace after expected end before terminal classification. |
 | `RUN_UNKNOWN_TIMEOUT_SECONDS` | 1800 | Silence before interrupting a run with no expected end. |
-| `RUN_TERMINAL_STATE_TTL_SECONDS` | 86400 | TTL applied to namespaced terminal state keys found during cleanup. |
+| `RUN_TERMINAL_STATE_TTL_SECONDS` | 86400 | TTL applied to known namespaced terminal state keys during cleanup. |
+| `RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS` | 120 | Renewable task-lock TTL preventing overlapping evaluations. |
 
 Effective deployed values are not verifiable from repository code when the
 environment overrides these defaults.

--- a/backend/runs/services/lifecycle.py
+++ b/backend/runs/services/lifecycle.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 from typing import Literal
@@ -36,6 +36,22 @@ TERMINAL_STATES = {
     RunLifecycleStates.INTERRUPTED.value,
     RunLifecycleStates.SHORT_TURNED.value,
 }
+
+TERMINAL_TRIP_STATE_SUFFIXES = (
+    "position",
+    "current_stop_sequence",
+    "stop_id",
+    "current_status",
+    "timestamp",
+    "congestion_level",
+    "occupancy_status",
+    "occupancy_percentage",
+    "multi_carriage_details",
+    "stop_time_updates",
+    "delay",
+    "trip_properties",
+    "vehicle",
+)
 
 r = Redis(
     host=settings.REDIS_HOST,
@@ -153,6 +169,7 @@ def record_successful_poll(
         if run.run_lifecycle_state not in TERMINAL_STATES
         and run.schedule_relationship not in {"CANCELED", "DELETED"}
     ]
+    terminal_runs = [run for run in runs if run.run_lifecycle_state in TERMINAL_STATES]
     transit_system = feed_publisher.transit_system.code
 
     with r.pipeline(transaction=True) as pipe:
@@ -178,6 +195,9 @@ def record_successful_poll(
                 occurred_at=observed_at,
                 last_seen_at=observed_at,
             )
+
+    for run in terminal_runs:
+        _apply_redis_transition(run, publish_event=False)
 
     for run in runs:
         if (
@@ -214,7 +234,11 @@ def publisher_realtime_healthy(
     return True
 
 
-def evaluate_active_runs(now: datetime | None = None) -> dict[str, int]:
+def evaluate_active_runs(
+    now: datetime | None = None,
+    *,
+    heartbeat: Callable[[], None] | None = None,
+) -> dict[str, int]:
     """Evaluate all canonical active sets and apply justified transitions."""
     now = now or timezone.now()
     counts: dict[str, int] = {}
@@ -234,7 +258,9 @@ def evaluate_active_runs(now: datetime | None = None) -> dict[str, int]:
         last_seen_by_id = dict(zip(run_ids, last_seen_scores))
         health_by_publisher: dict[int, bool] = {}
 
-        for run in runs:
+        for index, run in enumerate(runs):
+            if heartbeat is not None and index % 25 == 0:
+                heartbeat()
             if run.run_lifecycle_state in TERMINAL_STATES:
                 _apply_redis_transition(run, publish_event=False)
                 continue
@@ -253,6 +279,11 @@ def evaluate_active_runs(now: datetime | None = None) -> dict[str, int]:
                 else run.last_seen_at
             )
             if last_seen_at is None:
+                continue
+            if not health_by_publisher[publisher_id]:
+                continue
+            unseen_for = max(now - last_seen_at, timedelta())
+            if unseen_for < timedelta(seconds=settings.RUN_NO_SIGNAL_AFTER_SECONDS):
                 continue
 
             timing = _timing_evidence(run)
@@ -408,6 +439,10 @@ def transition_run(
 ) -> bool:
     """Persist one lifecycle transition and synchronize Redis after commit."""
     occurred_at = occurred_at or timezone.now()
+    changed = False
+    apply_redis_transition = False
+    publish_event = False
+    previous_state: str | None = None
     with r.lock(f"run:{run_id}:lifecycle_lock", timeout=15, blocking_timeout=5):
         with transaction.atomic():
             run = (
@@ -416,48 +451,49 @@ def transition_run(
                 .get(id=run_id)
             )
             previous_state = run.run_lifecycle_state
-            if previous_state == new_state:
-                if new_state in TERMINAL_STATES:
-                    transaction.on_commit(
-                        lambda: _apply_redis_transition(run, publish_event=False)
-                    )
-                return False
-            if previous_state in TERMINAL_STATES:
-                return False
+            if previous_state == new_state or previous_state in TERMINAL_STATES:
+                apply_redis_transition = previous_state in TERMINAL_STATES
+            else:
+                run.run_lifecycle_state = new_state
+                run.last_event_at = occurred_at
+                if last_seen_at is not None:
+                    run.last_seen_at = last_seen_at
+                if new_state == RunLifecycleStates.NO_SIGNAL.value:
+                    run.missing_since = last_seen_at or occurred_at
+                elif new_state == RunLifecycleStates.IN_PROGRESS.value:
+                    run.missing_since = None
+                    run.ended_at = None
+                    run.completion_reason = None
+                elif new_state in TERMINAL_STATES:
+                    run.ended_at = occurred_at
+                    run.completion_reason = reason
 
-            run.run_lifecycle_state = new_state
-            run.last_event_at = occurred_at
-            if last_seen_at is not None:
-                run.last_seen_at = last_seen_at
-            if new_state == RunLifecycleStates.NO_SIGNAL.value:
-                run.missing_since = last_seen_at or occurred_at
-            elif new_state == RunLifecycleStates.IN_PROGRESS.value:
-                run.missing_since = None
-                run.ended_at = None
-                run.completion_reason = None
-            elif new_state in TERMINAL_STATES:
-                run.ended_at = occurred_at
-                run.completion_reason = reason
-
-            run.save(
-                update_fields=[
-                    "run_lifecycle_state",
-                    "last_event_at",
-                    "last_seen_at",
-                    "missing_since",
-                    "ended_at",
-                    "completion_reason",
-                ]
-            )
-            transaction.on_commit(
-                lambda: _apply_redis_transition(
-                    run,
-                    reason=reason,
-                    previous_state=previous_state,
-                    publish_event=True,
+                run.save(
+                    update_fields=[
+                        "run_lifecycle_state",
+                        "last_event_at",
+                        "last_seen_at",
+                        "missing_since",
+                        "ended_at",
+                        "completion_reason",
+                    ]
                 )
+                changed = True
+                apply_redis_transition = True
+                publish_event = True
+
+    if apply_redis_transition:
+        # Register cleanup only after leaving the expirable Redis lock. This is
+        # still commit-safe if transition_run() is inside a wider transaction.
+        transaction.on_commit(
+            lambda: _apply_redis_transition(
+                run,
+                reason=reason,
+                previous_state=previous_state,
+                publish_event=publish_event,
             )
-    return True
+        )
+    return changed
 
 
 def _apply_redis_transition(
@@ -474,10 +510,11 @@ def _apply_redis_transition(
     terminal = state in TERMINAL_STATES
     remaining_stops_key = f"{system_code}:run:{run_id}:remaining_stops"
     stop_ids = r.zrange(remaining_stops_key, 0, -1)
-    state_keys = []
-    if terminal:
-        state_keys.extend(r.scan_iter(match=f"{system_code}:trip:{run_id}:*"))
-        state_keys.extend(r.scan_iter(match=f"{system_code}:run:{run_id}:*"))
+    state_keys = [
+        f"{system_code}:trip:{run_id}:{suffix}"
+        for suffix in TERMINAL_TRIP_STATE_SUFFIXES
+    ]
+    state_keys.append(f"{system_code}:run:{run_id}:lifecycle_state")
 
     with r.pipeline(transaction=True) as pipe:
         pipe.set(f"{system_code}:run:{run_id}:lifecycle_state", state)
@@ -486,7 +523,11 @@ def _apply_redis_transition(
             pipe.srem("trip:in_progress", run_id)
             pipe.zrem(last_seen_key(system_code), run_id)
             pipe.delete(remaining_stops_key)
-            pipe.delete(f"{system_code}:run:{run_id}:remaining_stops_initialized")
+            pipe.set(
+                f"{system_code}:run:{run_id}:remaining_stops_initialized",
+                "terminal",
+                ex=settings.RUN_TERMINAL_STATE_TTL_SECONDS,
+            )
             for stop_id in stop_ids:
                 pipe.srem(
                     f"{system_code}:stop:{stop_id}:approaching_runs",

--- a/backend/runs/services/realtime.py
+++ b/backend/runs/services/realtime.py
@@ -12,11 +12,11 @@ r = Redis(
 )
 
 
-def confirm_run(
+def confirm_run_record(
     feed_publisher: FeedPublisher,
     trip: gtfs_rt.TripDescriptor,
-) -> UUID:
-    """Find or create a run for a GTFS trip descriptor and synchronize its database and Redis metadata."""
+) -> Run:
+    """Return the run confirmed from a GTFS descriptor and sync its metadata."""
     schedule_relationship = None
     if trip.HasField("schedule_relationship"):
         enum_type = trip.DESCRIPTOR.fields_by_name["schedule_relationship"].enum_type
@@ -86,4 +86,12 @@ def confirm_run(
                 f"trip:{run.id}:trip",
                 mapping=redis_trip_descriptor,
             )
-    return run.id
+    return run
+
+
+def confirm_run(
+    feed_publisher: FeedPublisher,
+    trip: gtfs_rt.TripDescriptor,
+) -> UUID:
+    """Return the UUID confirmed from a GTFS trip descriptor."""
+    return confirm_run_record(feed_publisher, trip).id

--- a/backend/runs/services/state.py
+++ b/backend/runs/services/state.py
@@ -41,7 +41,8 @@ from uuid import UUID
 from django.conf import settings
 from feed.models import FeedPublisher
 from google.transit import gtfs_realtime_pb2 as gtfs_rt
-from runs.services.realtime import confirm_run
+from runs.services.lifecycle import TERMINAL_STATES
+from runs.services.realtime import confirm_run_record
 from runs.events.detector import EventDetector
 from runs.services.stop_index import advance_remaining_stops, sync_remaining_stops
 
@@ -126,8 +127,11 @@ def update_vehicle_positions_state(
         v = entity.vehicle
         if not v.HasField("trip"):
             continue
-        run_id = confirm_run(feed_publisher, v.trip)
+        run = confirm_run_record(feed_publisher, v.trip)
+        run_id = run.id
         observed_run_ids.add(run_id)
+        if run.run_lifecycle_state in TERMINAL_STATES:
+            continue
 
         # trip:<run_id>:position (Redis: hash)
         if v.HasField("position"):
@@ -250,8 +254,11 @@ def update_trip_updates_state(
         t = entity.trip_update
         if not t.HasField("trip"):
             continue
-        run_id = confirm_run(feed_publisher, t.trip)
+        run = confirm_run_record(feed_publisher, t.trip)
+        run_id = run.id
         observed_run_ids.add(run_id)
+        if run.run_lifecycle_state in TERMINAL_STATES:
+            continue
 
         # trip:<run_id>:stop_time_updates (Redis: JSON)
         stop_time_updates = []

--- a/backend/runs/services/state.py
+++ b/backend/runs/services/state.py
@@ -36,7 +36,7 @@ By trip updates:
 from collections.abc import Callable
 from redis import Redis
 from redis.exceptions import WatchError
-from typing import TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar
 from uuid import UUID
 from django.conf import settings
 from feed.models import FeedPublisher
@@ -55,6 +55,30 @@ StateDetector: TypeAlias = Callable[
 r = Redis(
     host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_CELERY_DB
 )
+
+
+def _optional_enum_name(message: Any, field_name: str) -> str | None:
+    """Return the stable protobuf enum name when an optional enum is present."""
+    if not message.HasField(field_name):
+        return None
+    field = message.DESCRIPTOR.fields_by_name[field_name]
+    return field.enum_type.values_by_number[int(getattr(message, field_name))].name
+
+
+def _stop_time_event_state(
+    stop_time_update: gtfs_rt.TripUpdate.StopTimeUpdate,
+    field_name: str,
+) -> dict[str, int | None]:
+    """Serialize an optional StopTimeEvent without leaking protobuf defaults."""
+    if not stop_time_update.HasField(field_name):
+        return {"delay": None, "time": None, "uncertainty": None}
+
+    event = getattr(stop_time_update, field_name)
+    return {
+        "delay": event.delay if event.HasField("delay") else None,
+        "time": event.time if event.HasField("time") else None,
+        "uncertainty": (event.uncertainty if event.HasField("uncertainty") else None),
+    }
 
 
 def _update_state_and_publish_event(
@@ -234,30 +258,16 @@ def update_trip_updates_state(
         for stu in t.stop_time_update:
             stop_time_updates.append(
                 {
-                    "stop_sequence": stu.stop_sequence,
-                    "stop_id": stu.stop_id,
-                    "arrival": {
-                        "delay": stu.arrival.delay
-                        if stu.arrival.HasField("delay")
-                        else None,
-                        "time": stu.arrival.time
-                        if stu.arrival.HasField("time")
-                        else None,
-                        "uncertainty": stu.arrival.uncertainty
-                        if stu.arrival.HasField("uncertainty")
-                        else None,
-                    },
-                    "departure": {
-                        "delay": stu.departure.delay
-                        if stu.departure.HasField("delay")
-                        else None,
-                        "time": stu.departure.time
-                        if stu.departure.HasField("time")
-                        else None,
-                        "uncertainty": stu.departure.uncertainty
-                        if stu.departure.HasField("uncertainty")
-                        else None,
-                    },
+                    "stop_sequence": (
+                        stu.stop_sequence if stu.HasField("stop_sequence") else None
+                    ),
+                    "stop_id": stu.stop_id if stu.HasField("stop_id") else None,
+                    "arrival": _stop_time_event_state(stu, "arrival"),
+                    "departure": _stop_time_event_state(stu, "departure"),
+                    "schedule_relationship": _optional_enum_name(
+                        stu,
+                        "schedule_relationship",
+                    ),
                 }
             )
         sync_remaining_stops(

--- a/backend/runs/services/stop_index.py
+++ b/backend/runs/services/stop_index.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from feed.models import Feed, StopTime
 from redis import Redis
 from runs.models import Run
+from runs.services.lifecycle import TERMINAL_STATES
 
 
 r = Redis(
@@ -65,7 +66,12 @@ def ensure_remaining_stops(transit_system: str, run_id: UUID | str) -> None:
         id=run_id,
         feed_publisher__transit_system__code=transit_system,
     ).first()
-    if run is None or not run.trip_id:
+    if (
+        run is None
+        or not run.trip_id
+        or run.run_lifecycle_state in TERMINAL_STATES
+        or run.schedule_relationship in {"CANCELED", "DELETED"}
+    ):
         return
 
     current_feed = (

--- a/backend/runs/tests.py
+++ b/backend/runs/tests.py
@@ -1,14 +1,21 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from django.test import SimpleTestCase, override_settings
 from google.transit import gtfs_realtime_pb2 as gtfs_rt
 
 from runs.domain.lifecycle import RunLifecycleStates
-from runs.services.lifecycle import LifecycleEvidence, decide_run_lifecycle
+from runs.services.lifecycle import (
+    LifecycleEvidence,
+    _apply_redis_transition,
+    decide_run_lifecycle,
+    record_successful_poll,
+    transition_run,
+)
 from runs.services.state import update_trip_updates_state
+from runs.services.stop_index import ensure_remaining_stops
 
 
 @override_settings(
@@ -102,16 +109,19 @@ class RunLifecyclePolicyTests(SimpleTestCase):
 
 class TripUpdatesStateTests(SimpleTestCase):
     @patch("runs.services.state.sync_remaining_stops")
-    @patch("runs.services.state.confirm_run")
+    @patch("runs.services.state.confirm_run_record")
     @patch("runs.services.state.r")
     def test_preserves_presence_and_schedule_relationship_name(
         self,
         redis,
-        confirm_run,
+        confirm_run_record,
         sync_remaining_stops,
     ):
         run_id = uuid4()
-        confirm_run.return_value = run_id
+        confirm_run_record.return_value = SimpleNamespace(
+            id=run_id,
+            run_lifecycle_state=RunLifecycleStates.IN_PROGRESS.value,
+        )
         feed_publisher = SimpleNamespace(transit_system=SimpleNamespace(code="mbta"))
         message = gtfs_rt.FeedMessage()
         entity = message.entity.add()
@@ -138,3 +148,184 @@ class TripUpdatesStateTests(SimpleTestCase):
             {"delay": None, "time": None, "uncertainty": None},
         )
         sync_remaining_stops.assert_called_once()
+
+    @patch("runs.services.state.sync_remaining_stops")
+    @patch("runs.services.state.confirm_run_record")
+    @patch("runs.services.state.r")
+    def test_terminal_run_cannot_restore_trip_update_state(
+        self,
+        redis,
+        confirm_run_record,
+        sync_remaining_stops,
+    ):
+        run_id = uuid4()
+        confirm_run_record.return_value = SimpleNamespace(
+            id=run_id,
+            run_lifecycle_state=RunLifecycleStates.COMPLETED.value,
+        )
+        feed_publisher = SimpleNamespace(transit_system=SimpleNamespace(code="mbta"))
+        message = gtfs_rt.FeedMessage()
+        entity = message.entity.add()
+        entity.trip_update.trip.trip_id = "historical-trip"
+        update = entity.trip_update.stop_time_update.add()
+        update.stop_id = "A"
+        update.stop_sequence = 1
+        update.arrival.time = 123
+
+        observed = update_trip_updates_state(feed_publisher, message)
+
+        self.assertEqual(observed, {run_id})
+        sync_remaining_stops.assert_not_called()
+        redis.json.return_value.set.assert_not_called()
+
+
+@override_settings(RUN_TERMINAL_STATE_TTL_SECONDS=86400)
+class RunLifecycleRedisCleanupTests(SimpleTestCase):
+    @patch("runs.services.stop_index.Feed.objects")
+    @patch("runs.services.stop_index.Run.objects")
+    @patch("runs.services.stop_index.r")
+    def test_terminal_run_cannot_reinitialize_remaining_stops_from_schedule(
+        self,
+        redis,
+        run_objects,
+        feed_objects,
+    ):
+        run_id = uuid4()
+        redis.exists.return_value = False
+        run_objects.filter.return_value.first.return_value = SimpleNamespace(
+            id=run_id,
+            trip_id="historical-trip",
+            run_lifecycle_state=RunLifecycleStates.COMPLETED.value,
+            schedule_relationship="SCHEDULED",
+        )
+
+        ensure_remaining_stops("mbta", run_id)
+
+        feed_objects.filter.assert_not_called()
+        redis.pipeline.assert_not_called()
+
+    @patch("runs.services.lifecycle._apply_redis_transition")
+    @patch("runs.services.lifecycle.Run.objects")
+    @patch("runs.services.lifecycle.r")
+    def test_successful_poll_reconciles_observed_terminal_run(
+        self,
+        redis,
+        run_objects,
+        apply_redis_transition,
+    ):
+        run_id = uuid4()
+        run = SimpleNamespace(
+            id=run_id,
+            run_lifecycle_state=RunLifecycleStates.COMPLETED.value,
+            schedule_relationship=None,
+        )
+        run_objects.filter.return_value.select_related.return_value = [run]
+        feed_publisher = SimpleNamespace(
+            pk=1,
+            transit_system=SimpleNamespace(code="mbta"),
+        )
+        observed_at = datetime(2026, 8, 14, 12, tzinfo=UTC)
+
+        record_successful_poll(
+            feed_publisher,
+            "trip_updates",
+            [run_id],
+            observed_at=observed_at,
+        )
+
+        apply_redis_transition.assert_called_once_with(
+            run,
+            publish_event=False,
+        )
+        redis.pipeline.return_value.__enter__.return_value.execute.assert_called_once_with()
+
+    @patch("runs.services.lifecycle.transaction.on_commit")
+    @patch("runs.services.lifecycle.transaction.atomic")
+    @patch("runs.services.lifecycle.Run.objects")
+    @patch("runs.services.lifecycle.r")
+    def test_redis_cleanup_is_registered_after_lifecycle_lock_is_released(
+        self,
+        redis,
+        run_objects,
+        atomic,
+        on_commit,
+    ):
+        events: list[str] = []
+
+        class RecordingContext:
+            def __init__(self, name: str):
+                self.name = name
+
+            def __enter__(self):
+                events.append(f"{self.name}_enter")
+
+            def __exit__(self, *_args):
+                events.append(f"{self.name}_exit")
+
+        run = SimpleNamespace(
+            id=uuid4(),
+            run_lifecycle_state=RunLifecycleStates.IN_PROGRESS.value,
+            last_event_at=None,
+            last_seen_at=None,
+            missing_since=None,
+            ended_at=None,
+            completion_reason=None,
+            save=Mock(),
+        )
+        redis.lock.return_value = RecordingContext("lock")
+        atomic.return_value = RecordingContext("atomic")
+        run_objects.select_for_update.return_value.select_related.return_value.get.return_value = run
+        on_commit.side_effect = lambda _callback: events.append("on_commit")
+
+        changed = transition_run(
+            run.id,
+            RunLifecycleStates.COMPLETED.value,
+            "Reached terminal.",
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            events,
+            [
+                "lock_enter",
+                "atomic_enter",
+                "atomic_exit",
+                "lock_exit",
+                "on_commit",
+            ],
+        )
+
+    @patch("runs.services.lifecycle.r")
+    def test_terminal_cleanup_removes_indexes_without_global_scan(self, redis):
+        run_id = uuid4()
+        redis.zrange.return_value = ["A", "B"]
+        pipe = redis.pipeline.return_value.__enter__.return_value
+        run = SimpleNamespace(
+            id=run_id,
+            run_lifecycle_state=RunLifecycleStates.COMPLETED.value,
+            feed_publisher=SimpleNamespace(transit_system=SimpleNamespace(code="mbta")),
+        )
+
+        _apply_redis_transition(run, publish_event=False)
+
+        redis.scan_iter.assert_not_called()
+        pipe.srem.assert_any_call("mbta:runs:active", str(run_id))
+        pipe.srem.assert_any_call(
+            "mbta:stop:A:approaching_runs",
+            str(run_id),
+        )
+        pipe.srem.assert_any_call(
+            "mbta:stop:B:approaching_runs",
+            str(run_id),
+        )
+        pipe.delete.assert_any_call(f"mbta:run:{run_id}:remaining_stops")
+        pipe.set.assert_any_call(
+            f"mbta:run:{run_id}:remaining_stops_initialized",
+            "terminal",
+            ex=86400,
+        )
+        pipe.expire.assert_any_call(
+            f"mbta:trip:{run_id}:stop_time_updates",
+            86400,
+        )
+        pipe.execute.assert_called_once_with()

--- a/backend/runs/tests.py
+++ b/backend/runs/tests.py
@@ -1,9 +1,14 @@
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
 
 from django.test import SimpleTestCase, override_settings
+from google.transit import gtfs_realtime_pb2 as gtfs_rt
 
 from runs.domain.lifecycle import RunLifecycleStates
 from runs.services.lifecycle import LifecycleEvidence, decide_run_lifecycle
+from runs.services.state import update_trip_updates_state
 
 
 @override_settings(
@@ -93,3 +98,43 @@ class RunLifecyclePolicyTests(SimpleTestCase):
         )
 
         self.assertEqual(decision.state, RunLifecycleStates.INTERRUPTED.value)
+
+
+class TripUpdatesStateTests(SimpleTestCase):
+    @patch("runs.services.state.sync_remaining_stops")
+    @patch("runs.services.state.confirm_run")
+    @patch("runs.services.state.r")
+    def test_preserves_presence_and_schedule_relationship_name(
+        self,
+        redis,
+        confirm_run,
+        sync_remaining_stops,
+    ):
+        run_id = uuid4()
+        confirm_run.return_value = run_id
+        feed_publisher = SimpleNamespace(transit_system=SimpleNamespace(code="mbta"))
+        message = gtfs_rt.FeedMessage()
+        entity = message.entity.add()
+        entity.trip_update.trip.trip_id = "trip-1"
+        first = entity.trip_update.stop_time_update.add()
+        first.stop_id = "A"
+        first.stop_sequence = 0
+        first.arrival.delay = 0
+        first.arrival.time = 123
+        first.schedule_relationship = 1
+        second = entity.trip_update.stop_time_update.add()
+        second.stop_id = "B"
+
+        observed = update_trip_updates_state(feed_publisher, message)
+
+        self.assertEqual(observed, {run_id})
+        state = redis.json.return_value.set.call_args.args[2]
+        self.assertEqual(state[0]["stop_sequence"], 0)
+        self.assertEqual(state[0]["arrival"]["delay"], 0)
+        self.assertEqual(state[0]["schedule_relationship"], "SKIPPED")
+        self.assertIsNone(state[1]["stop_sequence"])
+        self.assertEqual(
+            state[1]["arrival"],
+            {"delay": None, "time": None, "uncertainty": None},
+        )
+        sync_remaining_stops.assert_called_once()

--- a/backend/updates/README.md
+++ b/backend/updates/README.md
@@ -85,6 +85,15 @@ behavioral parts:
 | Topic resolver | Which concrete topics are affected by this event?    | All remaining stops of the changed run                      |
 | Builder        | What is the complete current snapshot for one topic? | All approaching runs and their occupancy state for one stop |
 
+Some projections also attach a topic validator for semantic constraints
+that cannot be expressed by `TopicPattern`. Pattern matching selects a projection
+from its fixed entity, information, and selector segments; the validator then
+checks concrete selector values before a WebSocket subscription is registered.
+The stop-time projection uses this hook to require a canonical GTFS direction ID
+of `0` or `1`. (`backend/updates/registry.py:28-44`,
+`backend/updates/planner.py:25-31`,
+`backend/updates/projections/stop/stop_time_updates.py:11-29`)
+
 The corresponding registration is conceptually:
 
 ```python
@@ -171,6 +180,24 @@ mbta.trip.occupancy_status.by_run.019fc09f-2af5-75b0-baab-c9ec701db592
 mbta.stop.occupancy_status.by_stop.123
 ```
 
+The registered stop-time projection is:
+
+```text
+<transit_system>.stop.stop_time_updates.by_stop.<stop_id>.by_direction.<direction_id>
+```
+
+For example:
+
+```text
+mbta.stop.stop_time_updates.by_stop.123.by_direction.1
+```
+
+It produces the current GTFS Realtime stop-time predictions for active runs
+approaching one stop in one canonical GTFS direction. It is refreshed directly
+after successful TripUpdates polls and is also invalidated by run lifecycle
+events. (`backend/updates/registry.py:86-108`,
+`backend/engine/tasks.py:145-164`)
+
 The event parser also recognizes stop sequence, stop ID, vehicle status,
 congestion, occupancy percentage, and run lifecycle events. Event types without
 registered projections are validated and acknowledged without publishing a
@@ -210,6 +237,86 @@ sequenceDiagram
 One `OccupancyStatusChanged` event can affect multiple topics. The direct trip
 projection always resolves one topic. The stop projection resolves one topic for
 each remaining stop of the run.
+
+### Trip-update poll refresh
+
+Stop-time prediction changes do not publish one domain event per changed RedisJSON
+document. After a TripUpdates poll has persisted the feed, updated current run
+state, and recorded the successful poll, `engine.tasks` calls
+`refresh_active_stop_time_update_topics()` once for each successfully processed
+transit system. (`backend/engine/tasks.py:121-166`,
+`backend/runs/services/state.py:246-303`)
+
+```mermaid
+sequenceDiagram
+		participant E as engine.tasks
+		participant RS as runs.services.state
+		participant R as Redis state and indexes
+		participant F as updates.refresh
+		participant SUB as Subscription metadata
+		participant B as Stop-time builder
+		participant D as updates.dispatcher
+		participant WS as WebSocket clients
+
+		E->>RS: update_trip_updates_state
+		RS->>R: sync remaining-stop indexes
+		RS->>R: JSON.SET current stop-time updates
+		E->>E: record_successful_poll
+		E->>F: refresh_active_stop_time_update_topics
+		F->>SUB: read active topics
+		loop matching topic with subscribers
+				F->>F: parse and validate topic
+				F->>B: build current snapshot
+				B-->>F: complete stop/direction snapshot
+				F->>D: dispatch snapshot
+				D->>WS: realtime_message
+		end
+```
+
+The refresh considers only active subscriptions for the transit system and only
+topics registered to `stop_stop_time_updates`. It checks subscriber presence
+before collecting the topic and again immediately before building, validates the
+concrete topic, and isolates failures so one broken topic does not prevent later
+topics from being refreshed. (`backend/updates/refresh.py:24-68`)
+
+### Stop-time lifecycle invalidation
+
+Run lifecycle transitions use the normal Redis Stream path. Before terminal
+cleanup removes a run from the active set and stop indexes, the lifecycle service
+captures its indexed stop IDs. The cleanup and lifecycle event publication occur
+in the same Redis transaction, and the event carries those stops in
+`affected_stop_ids_json`. (`backend/runs/services/lifecycle.py:499-549`,
+`backend/runs/services/lifecycle.py:552-579`)
+
+```mermaid
+sequenceDiagram
+		participant L as runs.services.lifecycle
+		participant R as Redis
+		participant C as updates.client
+		participant P as Stop-time topic resolver
+		participant B as Stop-time builder
+		participant D as updates.dispatcher
+		participant WS as WebSocket clients
+
+		L->>R: capture remaining stop IDs
+		L->>R: update lifecycle state and indexes
+		L->>R: XADD lifecycle event with affected stops
+		C->>R: XREADGROUP updates
+		C->>P: process lifecycle event
+		P->>P: load Run direction and resolve stop topics
+		P->>B: rebuild each affected topic
+		B-->>P: current snapshot
+		P->>D: dispatch snapshot
+		D->>WS: realtime_message
+```
+
+The projection reacts to signal loss, signal restoration, completion,
+interruption, and cancellation. Its resolver loads the scoped `Run` direction,
+parses the captured stop list, removes duplicate stop IDs while preserving their
+order, and creates one qualified topic per affected stop. It resolves no topics
+when the run direction is unavailable or noncanonical, or when the captured stop
+list is not a JSON array. (`backend/updates/registry.py:98-107`,
+`backend/updates/projections/stop/stop_time_updates.py:32-68`)
 
 ### WebSocket subscription
 
@@ -278,6 +385,62 @@ snapshot:
 }
 ```
 
+### Qualified stop-time subscription
+
+A stop-time subscription must include both the stop and canonical direction:
+
+```json
+{
+  "action": "subscribe",
+  "topic": "mbta.stop.stop_time_updates.by_stop.123.by_direction.1"
+}
+```
+
+The initial snapshot and later dispatched snapshots use the same outer WebSocket
+envelope and the same builder-produced message shape.
+(`backend/updates/consumers.py:84-102`,
+`backend/updates/consumers.py:113-115`,
+`backend/updates/dispatcher.py:8-17`)
+
+```json
+{
+  "topic": "mbta.stop.stop_time_updates.by_stop.123.by_direction.1",
+  "message": {
+    "topic": "mbta.stop.stop_time_updates.by_stop.123.by_direction.1",
+    "stop_id": "123",
+    "direction_id": 1,
+    "stop_time_updates": [
+      {
+        "run_id": "019fc09f-2af5-75b0-baab-c9ec701db592",
+        "trip_id": "trip-123",
+        "route_id": "route-1",
+        "direction_id": 1,
+        "stop_id": "123",
+        "stop_sequence": 8,
+        "arrival": {
+          "delay": 30,
+          "time": 1785645000,
+          "uncertainty": null
+        },
+        "departure": {
+          "delay": null,
+          "time": 1785645030,
+          "uncertainty": null
+        },
+        "schedule_relationship": "SCHEDULED"
+      }
+    ]
+  }
+}
+```
+
+`trip_id`, `route_id`, `stop_sequence`, and `schedule_relationship` may be
+`null`. Arrival and departure remain objects whose `delay`, `time`, and
+`uncertainty` fields may independently be `null`. An empty
+`stop_time_updates` list is a valid current snapshot.
+(`backend/updates/schemas.py:16-50`,
+`backend/updates/builders/stop/stop_time_updates.py:185-221`)
+
 ### Unsubscribe
 
 ```json
@@ -339,6 +502,22 @@ mbta.stop.occupancy_status.by_stop.123
 | Qualifier selector | `by_direction`     | Optional additional selection dimension.                    |
 | Qualifier value    | `1`                | Optional qualifier value.                                   |
 
+The stop-time projection uses all seven segments:
+
+| Segment | Value example | Stop-time meaning |
+| --- | --- | --- |
+| Transit system | `mbta` | Scopes Redis state and `Run` records to one transit system. (`backend/updates/builders/stop/stop_time_updates.py:136-162`) |
+| Entity | `stop` | Selects the stop-level aggregate view. (`backend/updates/registry.py:92-97`) |
+| Information | `stop_time_updates` | Selects current GTFS Realtime stop predictions. (`backend/updates/registry.py:92-97`) |
+| Primary selector | `by_stop` | Interprets the primary value as a stop ID. (`backend/updates/registry.py:92-97`) |
+| Primary value | `123` | Filters prediction entries to the requested stop. (`backend/updates/builders/stop/stop_time_updates.py:131-132`, `backend/updates/builders/stop/stop_time_updates.py:171-173`) |
+| Qualifier selector | `by_direction` | Interprets the qualifier value as a GTFS direction ID. (`backend/updates/registry.py:92-97`) |
+| Qualifier value | `1` | Accepts only the canonical strings `0` and `1`. (`backend/updates/projections/stop/stop_time_updates.py:11-22`) |
+
+There is no route qualifier. One topic can therefore contain predictions from
+multiple routes when those runs approach the same stop in the selected direction.
+(`backend/updates/builders/stop/stop_time_updates.py:145-198`)
+
 The public topic is not used directly as a Channels group name. `TopicKey`
 hashes the public topic with SHA-256 and prefixes the digest with `updates.`. This
 produces deterministic group names that satisfy Channels' length and character
@@ -385,6 +564,22 @@ The remaining-stop indexes are owned by `runs.services.stop_index`, not by this
 app. They are documented here because stop topic resolution and snapshot
 building depend on them.
 
+### State read by the stop-time builder
+
+| Key | Type | Purpose |
+| --- | --- | --- |
+| `<transit_system>:runs:active` | set | Canonical membership of runs eligible for public snapshots. (`backend/runs/services/lifecycle.py:83-85`, `backend/updates/builders/stop/stop_time_updates.py:136-143`) |
+| `<transit_system>:stop:<stop_id>:approaching_runs` | set | Candidate run IDs indexed for the requested stop. (`backend/runs/services/stop_index.py:24-26`, `backend/runs/services/stop_index.py:105-107`) |
+| `<transit_system>:run:<run_id>:remaining_stops` | sorted set | Confirms that the stop remains at or ahead of current progress. (`backend/runs/services/stop_index.py:19-21`, `backend/runs/services/stop_index.py:110-123`) |
+| `<transit_system>:trip:<run_id>:current_stop_sequence` | string | Current progress used to reject earlier or sequence-less visits. (`backend/updates/builders/stop/stop_time_updates.py:87-102`, `backend/updates/builders/stop/stop_time_updates.py:175-183`) |
+| `<transit_system>:trip:<run_id>:stop_time_updates` | RedisJSON | Current arrival, departure, sequence, stop, and schedule-relationship values. (`backend/runs/services/state.py:263-293`) |
+
+The builder also queries scoped `Run` rows for the UUID, GTFS trip ID, GTFS
+route ID, transit system, and direction. It does not use the historical
+`feed.StopTimeUpdate` rows to construct the public snapshot.
+(`backend/updates/builders/stop/stop_time_updates.py:9-20`,
+`backend/updates/builders/stop/stop_time_updates.py:145-198`)
+
 ## Source layout
 
 ```text
@@ -395,17 +590,21 @@ updates/
 ├── events.py
 ├── exceptions.py
 ├── planner.py
+├── refresh.py
 ├── registry.py
 ├── routing.py
+├── schemas.py
 ├── subscriptions.py
 ├── topics.py
 ├── builders/
 │   ├── stop/
+│   │   ├── stop_time_updates.py
 │   │   └── occupancy_status.py
 │   └── trip/
 │       └── occupancy_status.py
 └── projections/
 		├── stop/
+		│   ├── stop_time_updates.py
 		│   └── occupancy_status.py
 		└── trip/
 				└── occupancy_status.py
@@ -526,6 +725,35 @@ values or transit system. `matches(topic)` compares entity, information type,
 primary selector, and qualifier selector. The registry uses it to locate the
 builder for an initial subscription snapshot.
 
+### `schemas.py`
+
+Defines and validates the public stop-time snapshot contract. All three models
+forbid undeclared fields. (`backend/updates/schemas.py:16-50`)
+
+#### `DirectionID` and `StopTimeScheduleRelationship`
+
+`DirectionID` is the integer literal union `0 | 1`.
+`StopTimeScheduleRelationship` accepts `SCHEDULED`, `SKIPPED`, `NO_DATA`, and
+`UNSCHEDULED`. (`backend/updates/schemas.py:7-13`)
+
+#### `StopTimeEventSnapshot`
+
+Represents one arrival or departure event. `delay`, Unix `time`, and
+`uncertainty` are independently optional integers. (`backend/updates/schemas.py:16-23`)
+
+#### `StopTimeUpdateSnapshot`
+
+Represents one current visit of one run to the selected stop. It contains run,
+trip, route, direction, stop, and sequence identifiers; complete arrival and
+departure event objects; and the optional normalized schedule relationship.
+(`backend/updates/schemas.py:26-39`)
+
+#### `StopTimeUpdatesByStopSnapshot`
+
+Represents the complete current list for one public stop/direction topic. It
+contains the rendered topic, selected stop ID, selected direction ID, and the
+validated list of visit snapshots. (`backend/updates/schemas.py:42-50`)
+
 ### `registry.py`
 
 Declares which projections exist and connects event types, topic resolution, and
@@ -541,6 +769,9 @@ An immutable configuration object with:
 - `triggers`: event classes that invalidate the projection.
 - `resolve_topics`: function that maps an event to concrete topics.
 - `build`: function that builds one topic's current snapshot.
+- `validate_topic`: optional semantic validation applied to a concrete
+  subscription topic before it is registered. (`backend/updates/registry.py:31-44`,
+  `backend/updates/planner.py:25-31`)
 
 #### `PROJECTIONS`
 
@@ -584,6 +815,35 @@ Finds the projection registered for a topic and calls its builder. It returns
 `None` if no projection supports that topic. `UpdatesConsumer` uses this method
 immediately after subscription.
 
+#### `validate_topic(topic)`
+
+Rejects topics that do not match a registered projection. When the matching
+`ProjectionSpec` has a `validate_topic` hook, it also applies that
+projection-specific validation before subscription state or Channels membership
+is changed. (`backend/updates/planner.py:25-31`,
+`backend/updates/consumers.py:84-98`)
+
+### `refresh.py`
+
+Provides the direct poll-driven invalidation path for active stop-time topics.
+It owns a decoded Redis client for the same database used by subscription
+metadata and identifies the target projection by the diagnostic name
+`stop_stop_time_updates`. (`backend/updates/refresh.py:1-21`)
+
+#### `refresh_active_stop_time_update_topics(transit_system)`
+
+Reads the active public topic set and parses each entry. It discards malformed
+topics, topics from other transit systems, topics handled by other projections,
+and topics whose per-topic subscriber set is empty. The remaining topics are
+deduplicated and processed in rendered-topic order.
+(`backend/updates/refresh.py:24-47`)
+
+Before each build, it repeats the registry and subscriber checks, applies the
+projection-specific validator, builds the current snapshot, and dispatches
+non-`None` payloads. Exceptions are logged per topic so later topics continue,
+and the return value is the number of snapshots successfully dispatched.
+(`backend/updates/refresh.py:46-68`)
+
 ### `dispatcher.py`
 
 Contains the final transport step.
@@ -625,6 +885,12 @@ protocol.
   action.
 - `realtime_message(event)` serializes dispatcher messages to the WebSocket.
 
+`subscribe()` validates the concrete topic before joining its Channels group or
+writing Redis subscription metadata. Consequently, a structurally valid but
+unregistered topic, or a stop-time topic with a noncanonical direction, receives
+a protocol error and creates no subscription. (`backend/updates/consumers.py:84-102`,
+`backend/updates/planner.py:25-31`)
+
 ### `subscriptions.py`
 
 Maintains Redis metadata about WebSocket subscriptions.
@@ -637,6 +903,20 @@ least one subscriber.
 #### `_subscribers_key(topic)`
 
 Returns the per-topic Redis key `subscriptions:<topic>`.
+
+#### `active_subscription_topics(redis)`
+
+Reads `active_subscriptions` and returns decoded public topic strings. This is
+the starting set for poll-driven stop-time refreshes.
+(`backend/updates/subscriptions.py:12-17`,
+`backend/updates/refresh.py:24-27`)
+
+#### `has_subscribers(redis, topic)`
+
+Checks the cardinality of `subscriptions:<topic>`. The poll refresh uses it both
+while selecting work and immediately before building a snapshot.
+(`backend/updates/subscriptions.py:20-22`,
+`backend/updates/refresh.py:39-53`)
 
 #### `add_subscription(redis, topic, channel_name)`
 
@@ -703,6 +983,42 @@ every stop that the run has not passed:
 Topic resolution answers **where** an update belongs. It does not build the
 outgoing message.
 
+### `projections/stop/stop_time_updates.py`
+
+#### `VALID_DIRECTION_IDS`
+
+Maps the only accepted public qualifier strings, `"0"` and `"1"`, to the
+corresponding integer GTFS direction IDs. (`backend/updates/projections/stop/stop_time_updates.py:11`)
+
+#### `direction_id_from_topic(topic)`
+
+Returns the canonical integer direction for a topic. Any missing, alternative,
+or noncanonical representation raises `InvalidTopicException`; values such as
+`"01"` are not normalized. (`backend/updates/projections/stop/stop_time_updates.py:14-22`)
+
+#### `validate_stop_time_updates_topic(topic)`
+
+Rejects an empty stop ID and delegates direction validation to
+`direction_id_from_topic()`. Structural selector matching has already happened
+in the registry before this semantic validation runs.
+(`backend/updates/projections/stop/stop_time_updates.py:25-29`,
+`backend/updates/planner.py:25-31`)
+
+#### `resolve_stop_time_updates_topics(event)`
+
+Resolves lifecycle invalidations rather than ordinary prediction changes. It
+queries the event's `Run` within the event's transit system and returns no topics
+unless the persisted direction is `0` or `1`.
+(`backend/updates/projections/stop/stop_time_updates.py:32-45`)
+
+It then parses `affected_stop_ids_json`, requires a JSON list, stringifies
+nonempty entries, and deduplicates them in original order. Each stop becomes:
+
+```text
+<transit_system>.stop.stop_time_updates.by_stop.<stop_id>.by_direction.<direction_id>
+```
+
+Malformed JSON or a non-list value resolves to no topics.
 ### `builders/trip/occupancy_status.py`
 
 #### `build_trip_occupancy_status(topic)`
@@ -772,6 +1088,89 @@ The resulting snapshot has this shape:
 
 An empty `runs` list is a valid snapshot.
 
+### `builders/stop/stop_time_updates.py`
+
+Builds the complete current prediction list for one stop and direction. It uses
+run lifecycle membership and stop indexes as its primary eligibility boundary,
+then applies per-entry progress, schema, schedule-relationship, and freshness
+filters. (`backend/updates/builders/stop/stop_time_updates.py:123-221`)
+
+#### `SCHEDULE_RELATIONSHIPS`
+Maps the four GTFS Realtime numeric StopTimeUpdate schedule relationships to
+their stable names: `SCHEDULED`, `SKIPPED`, `NO_DATA`, and `UNSCHEDULED`.
+(`backend/updates/builders/stop/stop_time_updates.py:31-36`)
+
+#### `_decode_stop_time_updates(value)`
+
+Accepts current RedisJSON arrays, bytes, and the legacy JSON-string
+representation. Invalid JSON and non-list values produce an empty list; values
+inside a valid list are retained only when they are dictionaries.
+(`backend/updates/builders/stop/stop_time_updates.py:39-50`)
+
+#### `_schedule_relationship_name(value)`
+
+Normalizes known integer values, digit strings, and case-insensitive known names.
+Unknown values are deliberately left unchanged so Pydantic rejects corruption
+instead of silently converting it. Booleans are also left invalid rather than
+being treated as integers. (`backend/updates/builders/stop/stop_time_updates.py:53-67`)
+
+#### `_event_snapshot(value)`
+
+Builds an arrival or departure snapshot from the `delay`, `time`, and
+`uncertainty` fields of a dictionary. Missing or non-dictionary events become an
+event object whose three fields are `None`.
+(`backend/updates/builders/stop/stop_time_updates.py:70-76`,
+`backend/updates/schemas.py:16-23`)
+
+#### `_current_documents(transit_system, run_ids)`
+
+Uses one non-transactional Redis pipeline to read all current stop-time
+RedisJSON documents followed by all current stop-sequence strings. Invalid
+sequence values are represented as `None`; an empty run list performs no Redis
+commands. (`backend/updates/builders/stop/stop_time_updates.py:79-102`)
+
+#### `_predicted_time(update)`
+
+Uses `arrival.time` when present and otherwise uses `departure.time`. This same
+effective timestamp drives freshness filtering and ordering.
+(`backend/updates/builders/stop/stop_time_updates.py:105-109`,
+`backend/updates/builders/stop/stop_time_updates.py:209-214`)
+
+#### `_sort_key(update)`
+
+Sorts known effective timestamps before unknown timestamps, then by timestamp,
+run UUID, sequence presence, and sequence value. Repeated visits to the same
+stop are preserved as separate entries.
+(`backend/updates/builders/stop/stop_time_updates.py:112-120`,
+`backend/updates/builders/stop/stop_time_updates.py:171-214`)
+
+#### `build_stop_time_updates(topic)`
+
+Builds one complete snapshot in this order:
+
+1. Reads the stop and validated direction from the topic and computes the oldest
+   allowed predicted time. (`backend/updates/builders/stop/stop_time_updates.py:131-135`)
+2. Intersects the stop's approaching-run index with the canonical active-run set
+   and verifies that each run still approaches the stop.
+   (`backend/updates/builders/stop/stop_time_updates.py:136-144`)
+3. Loads scoped `Run` rows and retains only the selected GTFS direction.
+   (`backend/updates/builders/stop/stop_time_updates.py:145-158`)
+4. Bulk-reads current prediction documents and current sequences.
+   (`backend/updates/builders/stop/stop_time_updates.py:160-169`)
+5. Retains entries for the selected stop whose sequence is parseable and has not
+   fallen behind current progress. (`backend/updates/builders/stop/stop_time_updates.py:171-183`)
+6. Constructs the strict public schema and discards individual entries that fail
+   Pydantic validation. (`backend/updates/builders/stop/stop_time_updates.py:185-206`)
+7. Excludes `SKIPPED` visits and predictions older than the configured tolerance.
+   Timestamp-free visits remain eligible. (`backend/updates/builders/stop/stop_time_updates.py:207-212`)
+8. Sorts the surviving entries and returns a JSON-compatible aggregate snapshot,
+   including a valid empty list when no entry survives.
+   (`backend/updates/builders/stop/stop_time_updates.py:214-221`)
+
+The module-level name `stop_time_updates` remains an alias of the registered
+builder so the legacy `builders.message_builder` import remains importable.
+(`backend/updates/builders/stop/stop_time_updates.py:224-225`)
+
 ### `tests.py`
 
 The current focused tests cover:
@@ -785,6 +1184,14 @@ The current focused tests cover:
 - Resolving direct trip occupancy topics.
 - Resolving all remaining stop occupancy topics.
 - Planner coordination from resolution through dispatch.
+- Parsing and semantically validating qualified stop-time topics.
+  (`backend/updates/tests.py:61-68`, `backend/updates/tests.py:211-224`)
+- Building empty and populated stop-time snapshots, including repeated visits,
+  direction and transit-system isolation, sequence progress, schedule
+  relationships, temporal tolerance, and deterministic ordering.
+  (`backend/updates/tests.py:226-374`, `backend/updates/tests.py:377-677`)
+- Refreshing only active matching topics and isolating one topic failure from
+  later refreshes. (`backend/updates/tests.py:680-751`)
 
 The tests mock projection dependencies and do not replace the live integration
 checks for Redis Streams, RedisJSON, Channels, or the database.
@@ -888,6 +1295,20 @@ events to the `events` stream. Event schemas are defined in
 `runs.events.types`; `updates.events` imports those schemas rather than defining
 a second wire contract.
 
+### Trip-update poll integration
+
+`engine.tasks` imports `refresh_active_stop_time_update_topics()` directly from
+`updates.refresh`. This is an in-process Python interface from the polling
+orchestrator into the delivery app; it does not pass through the `events` Redis
+Stream. (`backend/engine/tasks.py:19-28`,
+`backend/engine/tasks.py:157-164`)
+
+The call occurs only after a publisher's TripUpdates response has been persisted,
+its current run state has been updated, and the successful poll has been
+recorded. Transit systems are deduplicated before refresh, so multiple processed
+publishers in one system produce one refresh call at the end of the task.
+(`backend/engine/tasks.py:121-166`)
+
 ### Remaining-stop index
 
 `runs.services.stop_index` maintains the run-to-stop and stop-to-run indexes used
@@ -952,6 +1373,16 @@ Use the following sequence when adding another information type.
    builds a complete current snapshot for one topic.
 4. **Register the projection.** Add a `ProjectionSpec` to `PROJECTIONS` with the
    topic pattern, event triggers, resolver, and builder.
+
+When a topic has semantic constraints on selector values, set
+`ProjectionSpec.validate_topic` so invalid subscriptions are rejected before
+Channels and Redis subscription state are changed. Poll-driven projections also
+need an explicit producer-side call analogous to the TripUpdates integration;
+registration in `PROJECTIONS` only enables event lookup and subscription-time
+building. (`backend/updates/registry.py:34-44`,
+`backend/updates/planner.py:25-31`,
+`backend/engine/tasks.py:157-164`)
+
 5. **Add tests.** Cover topic resolution, snapshot shape, planner dispatch, and
    first-subscription behavior.
 6. **Validate live delivery.** Subscribe a WebSocket client, publish a controlled
@@ -1020,6 +1451,43 @@ shows raw WebSocket messages.
   after retry.
 - There is no stream trimming policy in this app yet.
 - Dead-letter entries have no automated replay workflow.
+- Stop-time prediction changes do not publish their own typed event. Existing
+  subscribed topics are refreshed after successful TripUpdates polls, while
+  lifecycle events provide the event-stream invalidation path.
+  (`backend/runs/services/state.py:246-303`,
+  `backend/updates/registry.py:98-107`,
+  `backend/engine/tasks.py:157-164`)
+- Stop-time topics require a canonical direction of `0` or `1`. Runs without one
+  of those persisted values are absent from both lifecycle resolution and built
+  snapshots. (`backend/updates/projections/stop/stop_time_updates.py:36-45`,
+  `backend/updates/builders/stop/stop_time_updates.py:152-158`)
+- A current RedisJSON document is not sufficient by itself. A run must also be
+  present in the canonical active set, the stop's approaching-run set, the
+  remaining-stop sorted set, and a scoped `Run` row.
+  (`backend/updates/builders/stop/stop_time_updates.py:136-158`)
+- The snapshot exposes run, trip, route, direction, stop, and sequence
+  identifiers, but not rider-facing stop names, route names, or destination
+  headsigns. Those values exist in the Schedule `Stop`, `Route`, `Trip`, and
+  `StopTime` models, but the builder queries only `Run` and its transit-system
+  relation. (`backend/updates/schemas.py:26-50`,
+  `backend/feed/models.py:194-255`,
+  `backend/feed/models.py:314-338`,
+  `backend/gtfs-django/gtfs/models.py:50-64`,
+  `backend/gtfs-django/gtfs/models.py:118-135`,
+  `backend/gtfs-django/gtfs/models.py:248-267`,
+  `backend/gtfs-django/gtfs/models.py:285-303`,
+  `backend/updates/builders/stop/stop_time_updates.py:145-198`)
+- The remaining-stop indexes and current RedisJSON document are written by
+  separate Redis operations. There is no transaction spanning both writes, so a
+  concurrent snapshot build can observe the intermediate state.
+  (`backend/runs/services/state.py:280-293`,
+  `backend/runs/services/stop_index.py:34-57`)
+- Poll refreshes isolate builder and dispatcher failures per topic. Initial
+  subscription builds and Redis Stream event processing do not provide the same
+  per-topic isolation inside the planner.
+  (`backend/updates/refresh.py:46-62`,
+  `backend/updates/consumers.py:84-102`,
+  `backend/updates/planner.py:8-22`)
 - `ScreenConsumer` and `StatusConsumer` are not routed by this app.
 - Several builder/projection modules are placeholders.
 - Terminal lifecycle events carry affected stop IDs so occupancy snapshots are

--- a/backend/updates/README.md
+++ b/backend/updates/README.md
@@ -1019,6 +1019,8 @@ nonempty entries, and deduplicates them in original order. Each stop becomes:
 ```
 
 Malformed JSON or a non-list value resolves to no topics.
+(`backend/updates/projections/stop/stop_time_updates.py:47-68`)
+
 ### `builders/trip/occupancy_status.py`
 
 #### `build_trip_occupancy_status(topic)`
@@ -1096,6 +1098,7 @@ then applies per-entry progress, schema, schedule-relationship, and freshness
 filters. (`backend/updates/builders/stop/stop_time_updates.py:123-221`)
 
 #### `SCHEDULE_RELATIONSHIPS`
+
 Maps the four GTFS Realtime numeric StopTimeUpdate schedule relationships to
 their stable names: `SCHEDULED`, `SKIPPED`, `NO_DATA`, and `UNSCHEDULED`.
 (`backend/updates/builders/stop/stop_time_updates.py:31-36`)

--- a/backend/updates/README.md
+++ b/backend/updates/README.md
@@ -947,15 +947,12 @@ ws/updates/ -> UpdatesConsumer
 
 #### `resolve_trip_occupancy_topics(event)`
 
-Maps an `OccupancyStatusChanged` event to exactly one direct topic:
+Maps an `OccupancyStatusChanged` or `RunLifecycleEvent` event to exactly one direct topic:
 
 ```text
 <transit_system>.trip.occupancy_status.by_run.<run_id>
 ```
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
-> Estado: `parcial`. El resolver también acepta `RunLifecycleEvent`, no solo
-> `OccupancyStatusChanged`
 > (`backend/updates/projections/trip/occupancy_status.py:6-8`).
 
 No database or Redis query is required because the event already identifies the
@@ -972,7 +969,6 @@ every stop that the run has not passed:
 <transit_system>.stop.occupancy_status.by_stop.<stop_id>
 ```
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `parcial`. `remaining_stop_ids()` solo se llama para eventos de
 > ocupación; los eventos de ciclo de vida leen `affected_stop_ids_json`
 > directamente (`backend/updates/projections/stop/occupancy_status.py:9-15`).
@@ -1032,7 +1028,6 @@ Builds the current occupancy snapshot for one run:
 3. Returns the public topic, run ID, GTFS trip ID, route ID, and integer
    occupancy status.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `parcial`. El payload real también incluye `lifecycle_state`, campo no
 > reflejado en la enumeración anterior
 > (`backend/updates/builders/trip/occupancy_status.py:28-36`).
@@ -1059,7 +1054,6 @@ arrays.
 5. Adds trip, route, and arrival information.
 6. Sorts runs by known arrival time and then run ID.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `parcial`. Antes de comprobar si cada run todavía se aproxima a la
 > parada, el builder también descarta los runs fuera del conjunto activo; ese
 > filtro no aparece en la enumeración anterior
@@ -1083,7 +1077,6 @@ The resulting snapshot has this shape:
 }
 ```
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `parcial`. Cada entrada del payload real también incluye
 > `lifecycle_state`, campo no reflejado en el ejemplo anterior
 > (`backend/updates/builders/stop/occupancy_status.py:62-70`).
@@ -1199,7 +1192,6 @@ The current focused tests cover:
 The tests mock projection dependencies and do not replace the live integration
 checks for Redis Streams, RedisJSON, Channels, or the database.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `parcial`. El archivo contiene once tests. Además de los casos
 > enumerados, cubre el rechazo de un tópico que no es string
 > (`backend/updates/tests.py:46-51`), el parsing de un evento de ciclo de vida
@@ -1245,7 +1237,6 @@ Creates the database tables for the models in `models.py`.
 
 An empty package marker for Django's migration discovery.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `no encontrado`. En el árbol actual no existe
 > `backend/updates/migrations/` y `git ls-files -- backend/updates/migrations`
 > devuelve vacío: no hay migraciones de `updates` versionadas. La regla que
@@ -1347,7 +1338,6 @@ The app requires Redis Streams and RedisJSON. Development uses Redis 8, which
 provides the JSON commands used by the stop occupancy builder and run state
 service.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado de producción: `roto` en los tres puntos siguientes. Primero,
 > `streams-consumer` está declarado en desarrollo (`compose.dev.yml:70-87`),
 > pero no tiene un servicio equivalente en el mapa de servicios de producción
@@ -1507,13 +1497,156 @@ shows raw WebSocket messages.
 > (`backend/engine/templates/status.html:65-70`) y ASGI solo monta el routing de
 > `updates` (`backend/infobus/asgi.py:15-22`).
 
-> **[Aclaración documental]** La ruta real de esa plantilla es
-> `backend/engine/templates/status.html`; `engine/status.html` es una abreviación
-> imprecisa.
 
-> **[Verificado — Fase 2, HEAD 0fd8ad136d194daf088b65d36d1a806876309da3]**
 > Estado: `no encontrado`; decisión abierta. El contrato de tópico, evento y
 > mensaje no declara una versión: `Event` no incluye un campo de versión
 > (`backend/runs/events/types.py:35-44`) y `TopicKey` no contiene un segmento de
 > versión (`backend/updates/topics.py:8-16`). Esta nota no define ni resuelve el
 > esquema de versionado.
+
+## Route vehicle positions by route
+
+> Status: `implemented` (project state: `implementado`). The
+> `route_vehicle_positions` projection is registered with a concrete resolver,
+> builder, validator, poll refresh, and lifecycle triggers.
+> (`backend/updates/registry.py:114-135`)
+
+### Topic and segment contract
+
+The projection uses this five-segment topic:
+
+```text
+<transit_system>.route.vehicle_positions.by_route.<route_id>
+```
+
+For example:
+
+```text
+mbta.route.vehicle_positions.by_route.1
+```
+
+| Segment | Value example | Route vehicle-position meaning |
+| --- | --- | --- |
+| Transit system | `mbta` | Scopes both PostgreSQL runs and Redis state to one transit system. (`backend/updates/builders/route/vehicle_positions.py:75-83`, `backend/updates/builders/route/vehicle_positions.py:91-98`) |
+| Entity | `route` | Selects the route-level aggregate view. (`backend/updates/registry.py:120-124`) |
+| Information | `vehicle_positions` | Selects current GTFS Realtime vehicle positions. (`backend/updates/registry.py:115-124`) |
+| Primary selector | `by_route` | Interprets the primary value as a GTFS route ID. (`backend/updates/registry.py:120-124`) |
+| Primary value | `1` | Filters `Run` rows to the requested `route_id`. (`backend/updates/builders/route/vehicle_positions.py:72-80`) |
+
+There is no qualifier. The projection-specific validator requires only a
+nonempty primary value; structural matching of `route`, `vehicle_positions`,
+and `by_route` comes from the registry.
+(`backend/updates/projections/route/vehicle_positions.py:8-11`,
+`backend/updates/registry.py:120-124`)
+
+### Run resolution and snapshot construction
+
+The builder first queries PostgreSQL for `Run` rows whose `route_id` matches the
+topic, whose publisher belongs to the selected transit system, and whose
+lifecycle state is active. The active lifecycle states are `In Progress` and
+`No Signal`. (`backend/updates/builders/route/vehicle_positions.py:72-83`,
+`backend/runs/services/lifecycle.py:29-32`)
+
+Those database candidates are then intersected with the canonical
+`<transit_system>:runs:active` Redis set by one `SMISMEMBER` call. Both
+boundaries are necessary: `confirm_run_record()` can create a `Run` whose model
+default is already `In Progress` while the realtime state update is running,
+but `get_vehicle_positions()` calls `record_successful_poll()` only after that
+state update returns. The successful-poll recorder is what adds observed runs
+to the canonical active set. The intersection therefore prevents a newly
+created, database-active run from appearing in a public snapshot before a poll
+has successfully registered it. (`backend/runs/services/realtime.py:54-89`,
+`backend/runs/models.py:44-50`, `backend/runs/services/state.py:119-132`,
+`backend/engine/tasks.py:101-110`,
+`backend/runs/services/lifecycle.py:152-181`)
+
+For the remaining candidates, one non-transactional Redis pipeline reads every
+position hash and the ordered scalar state keys. The builder applies these
+exclusions in order:
+
+1. A run without membership in the canonical active set is excluded. This also
+   excludes every candidate when that set is absent.
+   (`backend/updates/builders/route/vehicle_positions.py:91-121`)
+2. A run without a parseable `latitude` or `longitude` in its position hash is
+   excluded. (`backend/updates/builders/route/vehicle_positions.py:33-41`,
+   `backend/updates/builders/route/vehicle_positions.py:123-135`)
+3. A run with a timestamp earlier than the freshness cutoff is excluded. A
+   missing timestamp does **not** exclude the run.
+   (`backend/updates/builders/route/vehicle_positions.py:107-109`,
+   `backend/updates/builders/route/vehicle_positions.py:137-153`)
+
+The cutoff is the current time minus
+`GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS`. The setting defaults to 120
+seconds. (`backend/infobus/settings.py:168-173`)
+
+Surviving vehicles are sorted by their textual `run_id` in ascending order.
+The builder always returns a complete snapshot: if the route has no candidate
+runs or every candidate is excluded, `vehicles` is an empty list. Because that
+snapshot is a dictionary rather than `None`, it is still sent on initial
+subscription and by poll or lifecycle invalidation.
+(`backend/updates/builders/route/vehicle_positions.py:67-69`,
+`backend/updates/builders/route/vehicle_positions.py:84-89`,
+`backend/updates/builders/route/vehicle_positions.py:208-213`,
+`backend/updates/consumers.py:100-102`, `backend/updates/refresh.py:47-61`,
+`backend/updates/planner.py:8-14`)
+
+### Invalidation paths
+
+Vehicle-position snapshots have two invalidation paths:
+
+1. **VehiclePositions poll refresh.** Each successfully processed publisher
+   poll saves the feed, updates current state, records the successful poll, and
+   marks its transit system for refresh. After the polling pass, each marked
+   system is refreshed once. The refresh selects active subscribed topics
+   registered to `route_vehicle_positions`, validates and rebuilds each topic,
+   and dispatches the snapshot while isolating per-topic failures.
+   (`backend/engine/tasks.py:76-120`, `backend/updates/refresh.py:21-70`,
+   `backend/updates/refresh.py:82-88`)
+2. **Run lifecycle invalidation.** The registered triggers are signal loss,
+   signal restoration, completion, interruption, and cancellation. The resolver
+   loads the run's `route_id` within the event's transit system and resolves one
+   route topic when that value is present; the normal event planner then rebuilds
+   and dispatches it. (`backend/updates/registry.py:125-134`,
+   `backend/updates/projections/route/vehicle_positions.py:14-37`,
+   `backend/updates/planner.py:8-14`)
+
+### Payload boundary
+
+The public vehicle schema exposes run, trip, route, and direction identifiers;
+coordinates; optional motion values; current stop state; congestion and
+occupancy state; and the vehicle timestamp. It does **not** enrich the payload
+with rider-facing route names or headsigns. Route-name and headsign enrichment
+is `not found` (project state: `no encontrado`): the builder selects only four
+fields from `Run` and performs no Schedule `Route` or `Trip` lookup.
+(`backend/updates/schemas.py:53-83`,
+`backend/updates/builders/route/vehicle_positions.py:75-83`)
+
+### Limitations
+
+- **Cross-publisher route aggregation — `implemented` (`implementado`).** A
+  Schedule `route_id` is unique within one feed, not within an entire transit
+  system. The builder deliberately filters by `route_id` and transit system,
+  without a publisher predicate, so runs for homonymous routes from different
+  publishers in the same system are aggregated into one topic.
+  (`backend/feed/models.py:244-252`,
+  `backend/updates/builders/route/vehicle_positions.py:75-83`)
+
+- **Incremental position hashes — `partial` (`parcial`).** State ingestion
+  removes absent fields from the mapping passed to `HSET`, but it never deletes
+  their previous hash fields. If a later VehiclePosition omits a field, an older
+  value can therefore persist. The builder receives only the resulting hash and
+  cannot distinguish “not supplied now” from “supplied previously.”
+  (`backend/runs/services/state.py:136-160`,
+  `backend/updates/builders/route/vehicle_positions.py:94-105`,
+  `backend/updates/builders/route/vehicle_positions.py:123-135`)
+- **VehiclePositions feed coverage — `partial` (`parcial`).** The topic can show
+  only runs for which the VehiclePositions feed has supplied usable coordinates.
+  TripUpdates can confirm a run and register it as active, but that path writes
+  stop-time state rather than a position hash, so a TripUpdates-only run fails
+  the coordinate requirement and does not appear even while active.
+  (`backend/runs/services/state.py:119-160`,
+  `backend/runs/services/state.py:246-293`, `backend/engine/tasks.py:159-168`,
+  `backend/runs/services/lifecycle.py:152-181`,
+  `backend/updates/builders/route/vehicle_positions.py:120-135`)
+
+

--- a/backend/updates/README.md
+++ b/backend/updates/README.md
@@ -903,6 +903,14 @@ by stop projections:
 - `advance_remaining_stops()` removes stops with lower sequences.
 - `clear_remaining_stops()` removes the index when a run is decommissioned.
 
+The stop `stop_time_updates` builder keeps those indexes and the canonical
+active-run set authoritative. As a public-boundary safeguard, it also excludes
+an update when its `arrival.time` (or `departure.time` when arrival is absent)
+is older than `GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS`, which defaults
+to 120 seconds. This covers polling/processing delay and vehicles dwelling at a
+stop; it does not replace terminal lifecycle cleanup. Updates with neither
+timestamp remain eligible from index/progress evidence and sort last.
+
 ### Django Channels
 
 The channel layer is configured in `infobus.settings`. The dispatcher and

--- a/backend/updates/builders/route/vehicle_positions.py
+++ b/backend/updates/builders/route/vehicle_positions.py
@@ -1,0 +1,213 @@
+import logging
+from typing import cast
+
+from django.conf import settings
+from django.utils import timezone
+from redis import Redis
+from runs.models import Run
+from runs.services.lifecycle import ACTIVE_STATES, active_runs_key
+
+from updates.schemas import VehiclePositionSnapshot, VehiclePositionsByRouteSnapshot
+from updates.topics import TopicKey
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+r: Redis = Redis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    db=settings.REDIS_CELERY_DB,
+    decode_responses=True,
+)
+
+SCALAR_FIELDS: tuple[str, ...] = (
+    "current_stop_sequence",
+    "stop_id",
+    "current_status",
+    "congestion_level",
+    "occupancy_status",
+    "occupancy_percentage",
+    "timestamp",
+)
+
+
+def _optional_float(value: object, *, key: str, run_id: str) -> float | None:
+    """Parse an optional float and warn when a present value is malformed."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning("Unable to parse Redis key %s for run %s as float", key, run_id)
+        return None
+
+
+def _optional_int(value: object, *, key: str, run_id: str) -> int | None:
+    """Parse an optional integer and warn when a present value is malformed."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Unable to parse Redis key %s for run %s as integer", key, run_id
+        )
+        return None
+
+
+def _position_field_key(position_key: str, field: str) -> str:
+    """Identify one field within a Redis position hash for logging."""
+    return f"{position_key}[{field}]"
+
+
+def _scalar_keys(transit_system: str, run_id: str) -> list[str]:
+    """Return the ordered Redis scalar keys for one run."""
+    return [f"{transit_system}:trip:{run_id}:{field}" for field in SCALAR_FIELDS]
+
+
+def _run_id_sort_key(vehicle: VehiclePositionSnapshot) -> str:
+    """Return the textual run identifier used by the public ordering contract."""
+    return str(vehicle.run_id)
+
+
+def build_route_vehicle_positions(topic: TopicKey) -> dict[str, object]:
+    """Build the current vehicle-position snapshot for one route."""
+    route_id: str = topic.primary_value
+    runs: list[Run] = list(
+        Run.objects.filter(
+            route_id=route_id,
+            feed_publisher__transit_system__code=topic.transit_system,
+            run_lifecycle_state__in=ACTIVE_STATES,
+        )
+        .only("id", "trip_id", "route_id", "direction_id")
+        .order_by("id")
+    )
+    if not runs:
+        return VehiclePositionsByRouteSnapshot(
+            topic=topic.render(),
+            route_id=route_id,
+            vehicles=[],
+        ).model_dump(mode="json")
+
+    run_ids: list[str] = [str(run.id) for run in runs]
+    with r.pipeline(transaction=False) as pipe:
+        pipe.smismember(active_runs_key(topic.transit_system), run_ids)
+        for run_id in run_ids:
+            pipe.hgetall(f"{topic.transit_system}:trip:{run_id}:position")
+        for run_id in run_ids:
+            pipe.mget(_scalar_keys(topic.transit_system, run_id))
+        values: list[object] = pipe.execute()
+
+    memberships: list[int] = cast(list[int], values[0])
+    positions: list[dict[str, str]] = cast(
+        list[dict[str, str]], values[1 : 1 + len(run_ids)]
+    )
+    scalar_values: list[list[str | None]] = cast(
+        list[list[str | None]], values[1 + len(run_ids) :]
+    )
+    stale_before: int = int(timezone.now().timestamp()) - int(
+        settings.GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS
+    )
+
+    vehicles: list[VehiclePositionSnapshot] = []
+    for run, run_id, is_active, position, raw_scalars in zip(
+        runs,
+        run_ids,
+        memberships,
+        positions,
+        scalar_values,
+        strict=True,
+    ):
+        if not is_active:
+            continue
+
+        position_key: str = f"{topic.transit_system}:trip:{run_id}:position"
+        latitude: float | None = _optional_float(
+            position.get("latitude"),
+            key=_position_field_key(position_key, "latitude"),
+            run_id=run_id,
+        )
+        longitude: float | None = _optional_float(
+            position.get("longitude"),
+            key=_position_field_key(position_key, "longitude"),
+            run_id=run_id,
+        )
+        if latitude is None or longitude is None:
+            continue
+
+        scalars: dict[str, str | None] = dict(
+            zip(SCALAR_FIELDS, raw_scalars, strict=True)
+        )
+        scalar_keys: dict[str, str] = dict(
+            zip(
+                SCALAR_FIELDS,
+                _scalar_keys(topic.transit_system, run_id),
+                strict=True,
+            )
+        )
+        timestamp: int | None = _optional_int(
+            scalars["timestamp"],
+            key=scalar_keys["timestamp"],
+            run_id=run_id,
+        )
+        if timestamp is not None and timestamp < stale_before:
+            continue
+
+        vehicles.append(
+            VehiclePositionSnapshot(
+                run_id=run.id,
+                trip_id=run.trip_id,
+                route_id=run.route_id,
+                direction_id=run.direction_id,
+                latitude=latitude,
+                longitude=longitude,
+                bearing=_optional_float(
+                    position.get("bearing"),
+                    key=_position_field_key(position_key, "bearing"),
+                    run_id=run_id,
+                ),
+                speed=_optional_float(
+                    position.get("speed"),
+                    key=_position_field_key(position_key, "speed"),
+                    run_id=run_id,
+                ),
+                odometer=_optional_float(
+                    position.get("odometer"),
+                    key=_position_field_key(position_key, "odometer"),
+                    run_id=run_id,
+                ),
+                current_stop_sequence=_optional_int(
+                    scalars["current_stop_sequence"],
+                    key=scalar_keys["current_stop_sequence"],
+                    run_id=run_id,
+                ),
+                stop_id=scalars["stop_id"],
+                current_status=_optional_int(
+                    scalars["current_status"],
+                    key=scalar_keys["current_status"],
+                    run_id=run_id,
+                ),
+                congestion_level=_optional_int(
+                    scalars["congestion_level"],
+                    key=scalar_keys["congestion_level"],
+                    run_id=run_id,
+                ),
+                occupancy_status=_optional_int(
+                    scalars["occupancy_status"],
+                    key=scalar_keys["occupancy_status"],
+                    run_id=run_id,
+                ),
+                occupancy_percentage=_optional_int(
+                    scalars["occupancy_percentage"],
+                    key=scalar_keys["occupancy_percentage"],
+                    run_id=run_id,
+                ),
+                timestamp=timestamp,
+            )
+        )
+
+    vehicles.sort(key=_run_id_sort_key)
+    return VehiclePositionsByRouteSnapshot(
+        topic=topic.render(),
+        route_id=route_id,
+        vehicles=vehicles,
+    ).model_dump(mode="json")

--- a/backend/updates/builders/stop/stop_time_updates.py
+++ b/backend/updates/builders/stop/stop_time_updates.py
@@ -1,3 +1,213 @@
-def stop_time_updates():
-    """No-op placeholder for the stop-level stop-time-update builder slot; the function currently takes no arguments and its body is only `pass`."""
-    pass
+import json
+import logging
+from typing import Any, cast
+
+from django.conf import settings
+from pydantic import ValidationError
+from redis import Redis
+from runs.models import Run
+from runs.services.lifecycle import active_runs_key
+from runs.services.stop_index import approaching_run_ids, run_is_approaching_stop
+
+from updates.projections.stop.stop_time_updates import direction_id_from_topic
+from updates.schemas import (
+    DirectionID,
+    StopTimeEventSnapshot,
+    StopTimeUpdateSnapshot,
+    StopTimeUpdatesByStopSnapshot,
+)
+from updates.topics import TopicKey
+
+
+logger = logging.getLogger(__name__)
+r = Redis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    db=settings.REDIS_CELERY_DB,
+    decode_responses=True,
+)
+
+SCHEDULE_RELATIONSHIPS = {
+    0: "SCHEDULED",
+    1: "SKIPPED",
+    2: "NO_DATA",
+    3: "UNSCHEDULED",
+}
+
+
+def _decode_stop_time_updates(value: object) -> list[dict[str, Any]]:
+    """Decode current RedisJSON and the legacy JSON-string representation."""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except TypeError, ValueError:
+            return []
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _schedule_relationship_name(value: object) -> Any:
+    """Normalize known GTFS enum encodings while leaving corruption invalid."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return SCHEDULE_RELATIONSHIPS.get(value, value)
+    if isinstance(value, str):
+        normalized = value.upper()
+        if normalized in SCHEDULE_RELATIONSHIPS.values():
+            return normalized
+        if normalized.isdigit():
+            return SCHEDULE_RELATIONSHIPS.get(int(normalized), value)
+    return value
+
+
+def _event_snapshot(value: object) -> StopTimeEventSnapshot:
+    event = value if isinstance(value, dict) else {}
+    return StopTimeEventSnapshot(
+        delay=event.get("delay"),
+        time=event.get("time"),
+        uncertainty=event.get("uncertainty"),
+    )
+
+
+def _current_documents(
+    transit_system: str,
+    run_ids: list[str],
+) -> tuple[list[object], list[int | None]]:
+    """Bulk-read prediction documents and current sequences for selected runs."""
+    if not run_ids:
+        return [], []
+
+    with r.pipeline(transaction=False) as pipe:
+        for run_id in run_ids:
+            pipe.json().get(f"{transit_system}:trip:{run_id}:stop_time_updates")
+        for run_id in run_ids:
+            pipe.get(f"{transit_system}:trip:{run_id}:current_stop_sequence")
+        values = pipe.execute()
+
+    document_values = values[: len(run_ids)]
+    sequence_values = values[len(run_ids) :]
+    current_sequences: list[int | None] = []
+    for value in sequence_values:
+        try:
+            current_sequences.append(int(value) if value is not None else None)
+        except TypeError, ValueError:
+            current_sequences.append(None)
+    return document_values, current_sequences
+
+
+def _sort_key(update: StopTimeUpdateSnapshot) -> tuple[int, int, str, bool, int]:
+    if update.arrival.time is not None:
+        time_rank = 0
+        event_time = update.arrival.time
+    elif update.departure.time is not None:
+        time_rank = 1
+        event_time = update.departure.time
+    else:
+        time_rank = 2
+        event_time = 0
+    return (
+        time_rank,
+        event_time,
+        str(update.run_id),
+        update.stop_sequence is None,
+        update.stop_sequence or 0,
+    )
+
+
+def build_stop_time_updates(topic: TopicKey) -> dict[str, object]:
+    """Build a complete current stop/direction snapshot from active Redis state."""
+    stop_id = topic.primary_value
+    direction_id = direction_id_from_topic(topic)
+    active_run_ids = {
+        str(run_id) for run_id in r.smembers(active_runs_key(topic.transit_system))
+    }
+    candidate_run_ids = [
+        run_id
+        for run_id in approaching_run_ids(topic.transit_system, stop_id)
+        if run_id in active_run_ids
+        if run_is_approaching_stop(topic.transit_system, run_id, stop_id)
+    ]
+    runs_by_id = {
+        str(run.id): run
+        for run in Run.objects.filter(
+            id__in=candidate_run_ids,
+            feed_publisher__transit_system__code=topic.transit_system,
+        ).select_related("feed_publisher__transit_system")
+    }
+    selected_run_ids = [
+        run_id
+        for run_id in candidate_run_ids
+        if (run := runs_by_id.get(run_id)) is not None
+        if run.feed_publisher.transit_system.code == topic.transit_system
+        if run.direction_id == direction_id
+    ]
+
+    documents, current_sequences = _current_documents(
+        topic.transit_system,
+        selected_run_ids,
+    )
+    updates: list[StopTimeUpdateSnapshot] = []
+    for run_id, document, current_sequence in zip(
+        selected_run_ids,
+        documents,
+        current_sequences,
+    ):
+        run = runs_by_id[run_id]
+        for raw_update in _decode_stop_time_updates(document):
+            if str(raw_update.get("stop_id")) != stop_id:
+                continue
+
+            raw_sequence = raw_update.get("stop_sequence")
+            try:
+                stop_sequence = int(raw_sequence) if raw_sequence is not None else None
+            except TypeError, ValueError:
+                continue
+            if current_sequence is not None and (
+                stop_sequence is None or stop_sequence < current_sequence
+            ):
+                continue
+
+            try:
+                update = StopTimeUpdateSnapshot(
+                    run_id=run.id,
+                    trip_id=run.trip_id,
+                    route_id=run.route_id,
+                    direction_id=cast(DirectionID, run.direction_id),
+                    stop_id=stop_id,
+                    stop_sequence=stop_sequence,
+                    arrival=_event_snapshot(raw_update.get("arrival")),
+                    departure=_event_snapshot(raw_update.get("departure")),
+                    schedule_relationship=_schedule_relationship_name(
+                        raw_update.get("schedule_relationship")
+                    ),
+                )
+            except ValidationError:
+                logger.warning(
+                    "Ignoring invalid current StopTimeUpdate for run %s and stop %s",
+                    run_id,
+                    stop_id,
+                    exc_info=True,
+                )
+                continue
+            if update.schedule_relationship == "SKIPPED":
+                continue
+            updates.append(update)
+
+    updates.sort(key=_sort_key)
+    snapshot = StopTimeUpdatesByStopSnapshot(
+        topic=topic.render(),
+        stop_id=stop_id,
+        direction_id=direction_id,
+        stop_time_updates=updates,
+    )
+    return snapshot.model_dump(mode="json")
+
+
+# Keep the legacy import in builders.message_builder importable.
+stop_time_updates = build_stop_time_updates

--- a/backend/updates/builders/stop/stop_time_updates.py
+++ b/backend/updates/builders/stop/stop_time_updates.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, cast
 
 from django.conf import settings
+from django.utils import timezone
 from pydantic import ValidationError
 from redis import Redis
 from runs.models import Run
@@ -42,7 +43,7 @@ def _decode_stop_time_updates(value: object) -> list[dict[str, Any]]:
     if isinstance(value, str):
         try:
             value = json.loads(value)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return []
     if not isinstance(value, list):
         return []
@@ -96,24 +97,23 @@ def _current_documents(
     for value in sequence_values:
         try:
             current_sequences.append(int(value) if value is not None else None)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             current_sequences.append(None)
     return document_values, current_sequences
 
 
-def _sort_key(update: StopTimeUpdateSnapshot) -> tuple[int, int, str, bool, int]:
+def _predicted_time(update: StopTimeUpdateSnapshot) -> int | None:
+    """Return the GTFS-RT event time relevant to this stop visit."""
     if update.arrival.time is not None:
-        time_rank = 0
-        event_time = update.arrival.time
-    elif update.departure.time is not None:
-        time_rank = 1
-        event_time = update.departure.time
-    else:
-        time_rank = 2
-        event_time = 0
+        return update.arrival.time
+    return update.departure.time
+
+
+def _sort_key(update: StopTimeUpdateSnapshot) -> tuple[bool, int, str, bool, int]:
+    predicted_time = _predicted_time(update)
     return (
-        time_rank,
-        event_time,
+        predicted_time is None,
+        predicted_time or 0,
         str(update.run_id),
         update.stop_sequence is None,
         update.stop_sequence or 0,
@@ -121,9 +121,18 @@ def _sort_key(update: StopTimeUpdateSnapshot) -> tuple[int, int, str, bool, int]
 
 
 def build_stop_time_updates(topic: TopicKey) -> dict[str, object]:
-    """Build a complete current stop/direction snapshot from active Redis state."""
+    """Build a complete current stop/direction snapshot from active Redis state.
+
+    Lifecycle and stop indexes remain authoritative. A small temporal tolerance
+    at this public boundary also prevents delayed cleanup from exposing
+    predictions that are hours or days old. Timestamp-free updates remain valid
+    because their indexed run/progress evidence can still be current.
+    """
     stop_id = topic.primary_value
     direction_id = direction_id_from_topic(topic)
+    earliest_relevant_time = int(timezone.now().timestamp()) - int(
+        settings.GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS
+    )
     active_run_ids = {
         str(run_id) for run_id in r.smembers(active_runs_key(topic.transit_system))
     }
@@ -166,7 +175,7 @@ def build_stop_time_updates(topic: TopicKey) -> dict[str, object]:
             raw_sequence = raw_update.get("stop_sequence")
             try:
                 stop_sequence = int(raw_sequence) if raw_sequence is not None else None
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
             if current_sequence is not None and (
                 stop_sequence is None or stop_sequence < current_sequence
@@ -196,6 +205,9 @@ def build_stop_time_updates(topic: TopicKey) -> dict[str, object]:
                 )
                 continue
             if update.schedule_relationship == "SKIPPED":
+                continue
+            predicted_time = _predicted_time(update)
+            if predicted_time is not None and predicted_time < earliest_relevant_time:
                 continue
             updates.append(update)
 

--- a/backend/updates/consumers.py
+++ b/backend/updates/consumers.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from redis import Redis
 
 from .exceptions import InvalidTopicException
-from .planner import build_topic_snapshot
+from .planner import build_topic_snapshot, validate_topic
 from .registry import Snapshot
 from .subscriptions import add_subscription, remove_subscription
 from .topics import TopicKey
@@ -83,6 +83,7 @@ class UpdatesConsumer(WebsocketConsumer):
 
     def subscribe(self, topic: TopicKey) -> None:
         """Join a topic and send its current snapshot when available."""
+        validate_topic(topic)
         group_name = topic.group_name()
         async_to_sync(self.channel_layer.group_add)(group_name, self.channel_name)
         try:

--- a/backend/updates/planner.py
+++ b/backend/updates/planner.py
@@ -1,5 +1,6 @@
 from .dispatcher import dispatch
 from .events import UpdateEvent
+from .exceptions import InvalidTopicException
 from .registry import Snapshot, projections_for_event, projection_for_topic
 from .topics import TopicKey
 
@@ -19,3 +20,12 @@ def build_topic_snapshot(topic: TopicKey) -> Snapshot | None:
     if projection is None:
         return None
     return projection.build(topic)
+
+
+def validate_topic(topic: TopicKey) -> None:
+    """Reject unregistered topics and apply projection-specific semantics."""
+    projection = projection_for_topic(topic)
+    if projection is None:
+        raise InvalidTopicException(topic.render(), "Topic is not registered.")
+    if projection.validate_topic is not None:
+        projection.validate_topic(topic)

--- a/backend/updates/projections/route/vehicle_positions.py
+++ b/backend/updates/projections/route/vehicle_positions.py
@@ -1,0 +1,37 @@
+from runs.events.types import RunLifecycleEvent
+from runs.models import Run
+
+from updates.exceptions import InvalidTopicException
+from updates.topics import TopicKey
+
+
+def validate_vehicle_positions_topic(topic: TopicKey) -> None:
+    """Validate the route ID required by the vehicle-position projection."""
+    if not topic.primary_value:
+        raise InvalidTopicException(topic.render(), "route_id cannot be empty.")
+
+
+def resolve_vehicle_positions_topics(
+    event: RunLifecycleEvent,
+) -> list[TopicKey]:
+    """Resolve a lifecycle invalidation to the run's route topic."""
+    route_id = (
+        Run.objects.filter(
+            id=event.run_id,
+            feed_publisher__transit_system__code=event.transit_system,
+        )
+        .values_list("route_id", flat=True)
+        .first()
+    )
+    if route_id is None or route_id == "":
+        return []
+
+    return [
+        TopicKey(
+            transit_system=event.transit_system,
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            primary_value=str(route_id),
+        )
+    ]

--- a/backend/updates/projections/stop/stop_time_updates.py
+++ b/backend/updates/projections/stop/stop_time_updates.py
@@ -1,0 +1,68 @@
+import json
+
+from runs.events.types import RunLifecycleEvent
+from runs.models import Run
+
+from updates.exceptions import InvalidTopicException
+from updates.schemas import DirectionID
+from updates.topics import TopicKey
+
+
+VALID_DIRECTION_IDS: dict[str, DirectionID] = {"0": 0, "1": 1}
+
+
+def direction_id_from_topic(topic: TopicKey) -> DirectionID:
+    """Return a canonical GTFS direction ID or reject the concrete topic."""
+    value = topic.qualifier_value
+    if value not in VALID_DIRECTION_IDS:
+        raise InvalidTopicException(
+            topic.render(),
+            "direction_id must be the canonical GTFS value 0 or 1.",
+        )
+    return VALID_DIRECTION_IDS[value]
+
+
+def validate_stop_time_updates_topic(topic: TopicKey) -> None:
+    """Validate the semantic values required by the stop-time projection."""
+    if not topic.primary_value:
+        raise InvalidTopicException(topic.render(), "stop_id cannot be empty.")
+    direction_id_from_topic(topic)
+
+
+def resolve_stop_time_updates_topics(
+    event: RunLifecycleEvent,
+) -> list[TopicKey]:
+    """Resolve lifecycle invalidations using captured stops and Run direction."""
+    direction_id = (
+        Run.objects.filter(
+            id=event.run_id,
+            feed_publisher__transit_system__code=event.transit_system,
+        )
+        .values_list("direction_id", flat=True)
+        .first()
+    )
+    if direction_id not in (0, 1):
+        return []
+
+    try:
+        raw_stop_ids = json.loads(event.affected_stop_ids_json or "[]")
+    except TypeError, ValueError:
+        return []
+    if not isinstance(raw_stop_ids, list):
+        return []
+
+    stop_ids = list(
+        dict.fromkeys(str(stop_id) for stop_id in raw_stop_ids if str(stop_id))
+    )
+    return [
+        TopicKey(
+            transit_system=event.transit_system,
+            entity="stop",
+            info="stop_time_updates",
+            primary_selector="by_stop",
+            primary_value=stop_id,
+            qualifier_selector="by_direction",
+            qualifier_value=str(direction_id),
+        )
+        for stop_id in stop_ids
+    ]

--- a/backend/updates/projections/stop/stop_time_updates.py
+++ b/backend/updates/projections/stop/stop_time_updates.py
@@ -46,7 +46,7 @@ def resolve_stop_time_updates_topics(
 
     try:
         raw_stop_ids = json.loads(event.affected_stop_ids_json or "[]")
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return []
     if not isinstance(raw_stop_ids, list):
         return []

--- a/backend/updates/refresh.py
+++ b/backend/updates/refresh.py
@@ -1,0 +1,68 @@
+import logging
+
+from django.conf import settings
+from redis import Redis
+
+from .dispatcher import dispatch
+from .exceptions import InvalidTopicException
+from .registry import projection_for_topic
+from .subscriptions import active_subscription_topics, has_subscribers
+from .topics import TopicKey
+
+
+logger = logging.getLogger(__name__)
+r = Redis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    db=settings.REDIS_CELERY_DB,
+    decode_responses=True,
+)
+
+PROJECTION_NAME = "stop_stop_time_updates"
+
+
+def refresh_active_stop_time_update_topics(transit_system: str) -> int:
+    """Rebuild and dispatch active stop-time topics after a successful poll."""
+    topics: set[TopicKey] = set()
+    for raw_topic in active_subscription_topics(r):
+        try:
+            topic = TopicKey.parse(raw_topic)
+        except InvalidTopicException:
+            logger.warning(
+                "Ignoring invalid topic in active subscriptions: %s",
+                raw_topic,
+            )
+            continue
+        if topic.transit_system != transit_system:
+            continue
+
+        projection = projection_for_topic(topic)
+        if projection is None or projection.name != PROJECTION_NAME:
+            continue
+        if not has_subscribers(r, raw_topic):
+            continue
+        topics.add(topic)
+
+    dispatched = 0
+    for topic in sorted(topics, key=TopicKey.render):
+        try:
+            projection = projection_for_topic(topic)
+            if projection is None or projection.name != PROJECTION_NAME:
+                continue
+            if not has_subscribers(r, topic.render()):
+                continue
+            if projection.validate_topic is not None:
+                projection.validate_topic(topic)
+            payload = projection.build(topic)
+            if payload is None:
+                continue
+            dispatch(topic, payload)
+            dispatched += 1
+        except Exception:
+            logger.exception("Failed to refresh active topic %s", topic.render())
+    logger.info(
+        "Refreshed %s active stop-time-update topics for transit system %s",
+        dispatched,
+        transit_system,
+    )
+    return dispatched

--- a/backend/updates/refresh.py
+++ b/backend/updates/refresh.py
@@ -18,11 +18,12 @@ r = Redis(
     decode_responses=True,
 )
 
-PROJECTION_NAME = "stop_stop_time_updates"
-
-
-def refresh_active_stop_time_update_topics(transit_system: str) -> int:
-    """Rebuild and dispatch active stop-time topics after a successful poll."""
+def _refresh_active_topics(
+    transit_system: str,
+    projection_name: str,
+    log_label: str,
+) -> int:
+    """Rebuild and dispatch active topics for a projection after a successful poll."""
     topics: set[TopicKey] = set()
     for raw_topic in active_subscription_topics(r):
         try:
@@ -37,7 +38,7 @@ def refresh_active_stop_time_update_topics(transit_system: str) -> int:
             continue
 
         projection = projection_for_topic(topic)
-        if projection is None or projection.name != PROJECTION_NAME:
+        if projection is None or projection.name != projection_name:
             continue
         if not has_subscribers(r, raw_topic):
             continue
@@ -47,7 +48,7 @@ def refresh_active_stop_time_update_topics(transit_system: str) -> int:
     for topic in sorted(topics, key=TopicKey.render):
         try:
             projection = projection_for_topic(topic)
-            if projection is None or projection.name != PROJECTION_NAME:
+            if projection is None or projection.name != projection_name:
                 continue
             if not has_subscribers(r, topic.render()):
                 continue
@@ -61,8 +62,27 @@ def refresh_active_stop_time_update_topics(transit_system: str) -> int:
         except Exception:
             logger.exception("Failed to refresh active topic %s", topic.render())
     logger.info(
-        "Refreshed %s active stop-time-update topics for transit system %s",
+        "Refreshed %s active %s topics for transit system %s",
         dispatched,
+        log_label,
         transit_system,
     )
     return dispatched
+
+
+def refresh_active_stop_time_update_topics(transit_system: str) -> int:
+    """Rebuild and dispatch active stop-time topics after a successful poll."""
+    return _refresh_active_topics(
+        transit_system,
+        "stop_stop_time_updates",
+        "stop-time-update",
+    )
+
+
+def refresh_active_vehicle_position_topics(transit_system: str) -> int:
+    """Rebuild and dispatch active route vehicle-position topics after a poll."""
+    return _refresh_active_topics(
+        transit_system,
+        "route_vehicle_positions",
+        "route-vehicle-position",
+    )

--- a/backend/updates/registry.py
+++ b/backend/updates/registry.py
@@ -12,10 +12,15 @@ from runs.events.types import (
     RunSignalRestored,
 )
 
+from .builders.route.vehicle_positions import build_route_vehicle_positions
 from .builders.stop.occupancy_status import build_stop_occupancy_status
 from .builders.stop.stop_time_updates import build_stop_time_updates
 from .builders.trip.occupancy_status import build_trip_occupancy_status
 from .events import UpdateEvent
+from .projections.route.vehicle_positions import (
+    resolve_vehicle_positions_topics,
+    validate_vehicle_positions_topic,
+)
 from .projections.stop.occupancy_status import resolve_stop_occupancy_topics
 from .projections.stop.stop_time_updates import (
     resolve_stop_time_updates_topics,
@@ -105,6 +110,28 @@ PROJECTIONS = (
         resolve_topics=resolve_stop_time_updates_topics,
         build=build_stop_time_updates,
         validate_topic=validate_stop_time_updates_topic,
+    ),
+    ProjectionSpec(
+        name="route_vehicle_positions",
+        description=(
+            "The current vehicle positions for active runs on a route, "
+            "by route ID."
+        ),
+        topic_pattern=TopicPattern(
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+        ),
+        triggers=(
+            RunSignalLost,
+            RunSignalRestored,
+            RunCompleted,
+            RunInterrupted,
+            RunCancelled,
+        ),
+        resolve_topics=resolve_vehicle_positions_topics,
+        build=build_route_vehicle_positions,
+        validate_topic=validate_vehicle_positions_topic,
     ),
 )
 

--- a/backend/updates/registry.py
+++ b/backend/updates/registry.py
@@ -13,9 +13,14 @@ from runs.events.types import (
 )
 
 from .builders.stop.occupancy_status import build_stop_occupancy_status
+from .builders.stop.stop_time_updates import build_stop_time_updates
 from .builders.trip.occupancy_status import build_trip_occupancy_status
 from .events import UpdateEvent
 from .projections.stop.occupancy_status import resolve_stop_occupancy_topics
+from .projections.stop.stop_time_updates import (
+    resolve_stop_time_updates_topics,
+    validate_stop_time_updates_topic,
+)
 from .projections.trip.occupancy_status import resolve_trip_occupancy_topics
 from .topics import TopicKey, TopicPattern
 
@@ -23,6 +28,7 @@ from .topics import TopicKey, TopicPattern
 Snapshot: TypeAlias = dict[str, object]
 TopicResolver: TypeAlias = Callable[[UpdateEvent], list[TopicKey]]
 SnapshotBuilder: TypeAlias = Callable[[TopicKey], Snapshot | None]
+TopicValidator: TypeAlias = Callable[[TopicKey], None]
 
 
 @dataclass(frozen=True)
@@ -35,6 +41,7 @@ class ProjectionSpec:
     triggers: tuple[type[Event], ...]
     resolve_topics: TopicResolver
     build: SnapshotBuilder
+    validate_topic: TopicValidator | None = None
 
 
 PROJECTIONS = (
@@ -75,6 +82,29 @@ PROJECTIONS = (
         ),
         resolve_topics=resolve_stop_occupancy_topics,
         build=build_stop_occupancy_status,
+    ),
+    ProjectionSpec(
+        name="stop_stop_time_updates",
+        description=(
+            "The current stop-time predictions for runs coming to a stop, "
+            "by stop ID and GTFS direction ID."
+        ),
+        topic_pattern=TopicPattern(
+            entity="stop",
+            info="stop_time_updates",
+            primary_selector="by_stop",
+            qualifier_selector="by_direction",
+        ),
+        triggers=(
+            RunSignalLost,
+            RunSignalRestored,
+            RunCompleted,
+            RunInterrupted,
+            RunCancelled,
+        ),
+        resolve_topics=resolve_stop_time_updates_topics,
+        build=build_stop_time_updates,
+        validate_topic=validate_stop_time_updates_topic,
     ),
 )
 

--- a/backend/updates/schemas.py
+++ b/backend/updates/schemas.py
@@ -48,3 +48,36 @@ class StopTimeUpdatesByStopSnapshot(BaseModel):
     stop_id: str
     direction_id: DirectionID
     stop_time_updates: list[StopTimeUpdateSnapshot]
+
+
+class VehiclePositionSnapshot(BaseModel):
+    """Represent one active run's current GTFS Realtime vehicle position."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: UUID
+    trip_id: str | None
+    route_id: str
+    direction_id: int | None
+    latitude: float
+    longitude: float
+    bearing: float | None
+    speed: float | None
+    odometer: float | None
+    current_stop_sequence: int | None
+    stop_id: str | None
+    current_status: int | None
+    congestion_level: int | None
+    occupancy_status: int | None
+    occupancy_percentage: int | None
+    timestamp: int | None
+
+
+class VehiclePositionsByRouteSnapshot(BaseModel):
+    """Represent all current vehicle positions for one route."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    topic: str
+    route_id: str
+    vehicles: list[VehiclePositionSnapshot]

--- a/backend/updates/schemas.py
+++ b/backend/updates/schemas.py
@@ -1,0 +1,50 @@
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+DirectionID = Literal[0, 1]
+StopTimeScheduleRelationship = Literal[
+    "SCHEDULED",
+    "SKIPPED",
+    "NO_DATA",
+    "UNSCHEDULED",
+]
+
+
+class StopTimeEventSnapshot(BaseModel):
+    """Represent the current GTFS Realtime prediction for one stop event."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    delay: int | None = None
+    time: int | None = None
+    uncertainty: int | None = None
+
+
+class StopTimeUpdateSnapshot(BaseModel):
+    """Represent one run's current prediction for one visit to a stop."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: UUID
+    trip_id: str | None
+    route_id: str | None
+    direction_id: DirectionID
+    stop_id: str
+    stop_sequence: int | None
+    arrival: StopTimeEventSnapshot
+    departure: StopTimeEventSnapshot
+    schedule_relationship: StopTimeScheduleRelationship | None = None
+
+
+class StopTimeUpdatesByStopSnapshot(BaseModel):
+    """Represent the complete current prediction list for a stop and direction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    topic: str
+    stop_id: str
+    direction_id: DirectionID
+    stop_time_updates: list[StopTimeUpdateSnapshot]

--- a/backend/updates/subscriptions.py
+++ b/backend/updates/subscriptions.py
@@ -9,6 +9,19 @@ def _subscribers_key(topic: str) -> str:
     return f"subscriptions:{topic}"
 
 
+def active_subscription_topics(redis: Redis) -> set[str]:
+    """Return the public topics currently marked active."""
+    return {
+        value.decode("utf-8") if isinstance(value, bytes) else str(value)
+        for value in redis.smembers(ACTIVE_SUBSCRIPTIONS_KEY)
+    }
+
+
+def has_subscribers(redis: Redis, topic: str) -> bool:
+    """Return whether a topic still has at least one registered channel."""
+    return bool(redis.scard(_subscribers_key(topic)))
+
+
 def add_subscription(redis: Redis, topic: str, channel_name: str) -> None:
     """Atomically register a channel and mark its topic active."""
     with redis.pipeline(transaction=True) as pipe:

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -1,8 +1,8 @@
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock, patch
-from uuid import uuid4
+from unittest.mock import Mock, call, patch
+from uuid import UUID, uuid4
 
 from channels.testing import WebsocketCommunicator
 from django.test import SimpleTestCase, override_settings
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from runs.events.types import OccupancyStatusChanged
 from runs.events.types import RunCompleted
+from updates.builders.route.vehicle_positions import build_route_vehicle_positions
 from updates.builders.stop.stop_time_updates import build_stop_time_updates
 from updates.consumers import UpdatesConsumer
 from updates.events import parse_event
@@ -877,3 +878,385 @@ class VehiclePositionSchemaTests(SimpleTestCase):
         )
 
         self.assertEqual(snapshot.model_dump(mode="json")["vehicles"], [])
+
+
+@override_settings(GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS=120)
+class RouteVehiclePositionsBuilderTests(SimpleTestCase):
+    now_timestamp: int = 1_800_000_000
+
+    def _scalar_keys(self, run_id: str) -> list[str]:
+        return [
+            f"mbta:trip:{run_id}:{field}"
+            for field in (
+                "current_stop_sequence",
+                "stop_id",
+                "current_status",
+                "congestion_level",
+                "occupancy_status",
+                "occupancy_percentage",
+                "timestamp",
+            )
+        ]
+
+    def _run(
+        self,
+        *,
+        run_id: UUID | None = None,
+        route_id: str = "route-a",
+        transit_system: str = "mbta",
+        trip_id: str | None = "trip-a",
+        direction_id: int | None = 1,
+        lifecycle_state: str = "In Progress",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=run_id or uuid4(),
+            trip_id=trip_id,
+            route_id=route_id,
+            direction_id=direction_id,
+            run_lifecycle_state=lifecycle_state,
+            feed_publisher=SimpleNamespace(
+                transit_system=SimpleNamespace(code=transit_system)
+            ),
+        )
+
+    def _snapshot(
+        self,
+        runs: list[SimpleNamespace],
+        positions: dict[str, dict[str, str]],
+        *,
+        scalars: dict[str, dict[str, str]] | None = None,
+        active_ids: set[str] | None = None,
+        transit_system: str = "mbta",
+        route_id: str = "route-a",
+        pipeline_values: list[object] | None = None,
+    ) -> tuple[dict[str, Any], Mock, Mock, Mock]:
+        run_ids = [str(run.id) for run in runs]
+        canonical_ids = set(run_ids) if active_ids is None else active_ids
+        scalars = scalars or {}
+
+        with (
+            patch("updates.builders.route.vehicle_positions.r") as redis,
+            patch(
+                "updates.builders.route.vehicle_positions.Run.objects.filter"
+            ) as filter_runs,
+            patch(
+                "updates.builders.route.vehicle_positions.timezone.now",
+                return_value=datetime.fromtimestamp(self.now_timestamp, tz=UTC),
+            ),
+        ):
+            filter_runs.return_value.only.return_value.order_by.return_value = runs
+            pipeline = redis.pipeline.return_value.__enter__.return_value
+            if pipeline_values is None:
+                pipeline_values = [
+                    [run_id in canonical_ids for run_id in run_ids],
+                    *[positions.get(run_id, {}) for run_id in run_ids],
+                    *[
+                        [
+                            scalars.get(run_id, {}).get(field)
+                            for field in (
+                                "current_stop_sequence",
+                                "stop_id",
+                                "current_status",
+                                "congestion_level",
+                                "occupancy_status",
+                                "occupancy_percentage",
+                                "timestamp",
+                            )
+                        ]
+                        for run_id in run_ids
+                    ],
+                ]
+            pipeline.execute.return_value = pipeline_values
+            topic = TopicKey.parse(
+                f"{transit_system}.route.vehicle_positions.by_route.{route_id}"
+            )
+            snapshot = build_route_vehicle_positions(topic)
+        return snapshot, redis, filter_runs, pipeline
+
+    def test_returns_empty_snapshot_when_route_has_no_active_runs(self):
+        snapshot, redis, _filter_runs, _pipeline = self._snapshot([], {})
+
+        self.assertEqual(snapshot["vehicles"], [])
+        self.assertEqual(
+            snapshot["topic"], "mbta.route.vehicle_positions.by_route.route-a"
+        )
+        self.assertEqual(snapshot["route_id"], "route-a")
+        redis.pipeline.assert_not_called()
+
+    def test_excludes_run_absent_from_canonical_active_set(self):
+        run = self._run()
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [run],
+            {
+                str(run.id): {
+                    "latitude": "9.93",
+                    "longitude": "-84.08",
+                }
+            },
+            active_ids=set(),
+        )
+
+        self.assertEqual(snapshot["vehicles"], [])
+
+    def test_excludes_position_without_latitude(self):
+        run = self._run()
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [run],
+            {str(run.id): {"longitude": "-84.08"}},
+        )
+
+        self.assertEqual(snapshot["vehicles"], [])
+
+    def test_excludes_position_without_longitude(self):
+        run = self._run()
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [run],
+            {str(run.id): {"latitude": "9.93"}},
+        )
+
+        self.assertEqual(snapshot["vehicles"], [])
+
+    def test_excludes_stale_timestamp_but_keeps_boundary(self):
+        stale = self._run()
+        boundary = self._run()
+        positions = {
+            str(run.id): {"latitude": "9.93", "longitude": "-84.08"}
+            for run in (stale, boundary)
+        }
+        scalars = {
+            str(stale.id): {"timestamp": str(self.now_timestamp - 121)},
+            str(boundary.id): {"timestamp": str(self.now_timestamp - 120)},
+        }
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [stale, boundary],
+            positions,
+            scalars=scalars,
+        )
+
+        self.assertEqual(
+            [vehicle["run_id"] for vehicle in snapshot["vehicles"]],
+            [str(boundary.id)],
+        )
+
+    def test_keeps_position_without_timestamp(self):
+        run = self._run()
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [run],
+            {
+                str(run.id): {
+                    "latitude": "9.93",
+                    "longitude": "-84.08",
+                }
+            },
+        )
+
+        self.assertEqual(len(snapshot["vehicles"]), 1)
+        self.assertIsNone(snapshot["vehicles"][0]["timestamp"])
+
+    def test_scopes_runs_to_transit_system_code(self):
+        valid = self._run()
+        foreign = self._run(transit_system="other")
+        positions = {
+            str(run.id): {"latitude": "9.93", "longitude": "-84.08"}
+            for run in (valid, foreign)
+        }
+
+        snapshot, _redis, filter_runs, _pipeline = self._snapshot(
+            [valid],
+            positions,
+            active_ids={str(valid.id), str(foreign.id)},
+        )
+
+        self.assertEqual(
+            [vehicle["run_id"] for vehicle in snapshot["vehicles"]],
+            [str(valid.id)],
+        )
+        filter_runs.assert_called_once_with(
+            route_id="route-a",
+            feed_publisher__transit_system__code="mbta",
+            run_lifecycle_state__in={"In Progress", "No Signal"},
+        )
+
+    def test_excludes_runs_in_terminal_lifecycle_states(self):
+        terminal = self._run(lifecycle_state="Completed")
+
+        snapshot, redis, filter_runs, _pipeline = self._snapshot(
+            [],
+            {
+                str(terminal.id): {
+                    "latitude": "9.93",
+                    "longitude": "-84.08",
+                }
+            },
+            active_ids={str(terminal.id)},
+        )
+
+        self.assertEqual(snapshot["vehicles"], [])
+        filter_runs.assert_called_once_with(
+            route_id="route-a",
+            feed_publisher__transit_system__code="mbta",
+            run_lifecycle_state__in={"In Progress", "No Signal"},
+        )
+        redis.pipeline.assert_not_called()
+
+    def test_sorts_vehicles_by_run_id(self):
+        higher = self._run(run_id=UUID("00000000-0000-0000-0000-000000000002"))
+        lower = self._run(run_id=UUID("00000000-0000-0000-0000-000000000001"))
+        positions = {
+            str(run.id): {"latitude": "9.93", "longitude": "-84.08"}
+            for run in (higher, lower)
+        }
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [higher, lower],
+            positions,
+        )
+
+        self.assertEqual(
+            [vehicle["run_id"] for vehicle in snapshot["vehicles"]],
+            [str(lower.id), str(higher.id)],
+        )
+
+    def test_serializes_all_optional_state_fields(self):
+        full = self._run(run_id=UUID("00000000-0000-0000-0000-000000000001"))
+        empty = self._run(
+            run_id=UUID("00000000-0000-0000-0000-000000000002"),
+            trip_id=None,
+            direction_id=None,
+        )
+        positions = {
+            str(full.id): {
+                "latitude": "9.934739",
+                "longitude": "-84.087502",
+                "bearing": "180.5",
+                "speed": "12.25",
+                "odometer": "5000.75",
+            },
+            str(empty.id): {
+                "latitude": "9.94",
+                "longitude": "-84.09",
+            },
+        }
+        scalars = {
+            str(full.id): {
+                "current_stop_sequence": "4",
+                "stop_id": "stop-a",
+                "current_status": "2",
+                "congestion_level": "1",
+                "occupancy_status": "3",
+                "occupancy_percentage": "65",
+                "timestamp": str(self.now_timestamp),
+            }
+        }
+
+        snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+            [full, empty],
+            positions,
+            scalars=scalars,
+        )
+
+        full_vehicle, empty_vehicle = snapshot["vehicles"]
+        self.assertEqual(full_vehicle["latitude"], 9.934739)
+        self.assertEqual(full_vehicle["longitude"], -84.087502)
+        self.assertEqual(full_vehicle["bearing"], 180.5)
+        self.assertEqual(full_vehicle["speed"], 12.25)
+        self.assertEqual(full_vehicle["odometer"], 5000.75)
+        self.assertEqual(full_vehicle["current_stop_sequence"], 4)
+        self.assertEqual(full_vehicle["stop_id"], "stop-a")
+        self.assertEqual(full_vehicle["current_status"], 2)
+        self.assertEqual(full_vehicle["congestion_level"], 1)
+        self.assertEqual(full_vehicle["occupancy_status"], 3)
+        self.assertEqual(full_vehicle["occupancy_percentage"], 65)
+        self.assertEqual(full_vehicle["timestamp"], self.now_timestamp)
+        for field in (
+            "trip_id",
+            "direction_id",
+            "bearing",
+            "speed",
+            "odometer",
+            "current_stop_sequence",
+            "stop_id",
+            "current_status",
+            "congestion_level",
+            "occupancy_status",
+            "occupancy_percentage",
+            "timestamp",
+        ):
+            self.assertIsNone(empty_vehicle[field])
+
+    def test_reads_all_vehicle_state_in_a_single_pipeline(self):
+        first = self._run(run_id=UUID("00000000-0000-0000-0000-000000000001"))
+        second = self._run(run_id=UUID("00000000-0000-0000-0000-000000000002"))
+        runs = [first, second]
+        positions = {
+            str(run.id): {"latitude": "9.93", "longitude": "-84.08"} for run in runs
+        }
+
+        _snapshot, redis, _filter_runs, pipeline = self._snapshot(runs, positions)
+
+        first_id, second_id = (str(run.id) for run in runs)
+        self.assertEqual(
+            pipeline.method_calls,
+            [
+                call.smismember("mbta:runs:active", [first_id, second_id]),
+                call.hgetall(f"mbta:trip:{first_id}:position"),
+                call.hgetall(f"mbta:trip:{second_id}:position"),
+                call.mget(self._scalar_keys(first_id)),
+                call.mget(self._scalar_keys(second_id)),
+                call.execute(),
+            ],
+        )
+        redis.pipeline.assert_called_once_with(transaction=False)
+        pipeline.execute.assert_called_once_with()
+        self.assertEqual(redis.method_calls, [call.pipeline(transaction=False)])
+
+    def test_malformed_numeric_value_logs_warning_and_yields_none(self):
+        run = self._run()
+
+        with self.assertLogs(
+            "updates.builders.route.vehicle_positions", level="WARNING"
+        ) as logs:
+            snapshot, _redis, _filter_runs, _pipeline = self._snapshot(
+                [run],
+                {
+                    str(run.id): {
+                        "latitude": "9.93",
+                        "longitude": "-84.08",
+                    }
+                },
+                scalars={str(run.id): {"timestamp": "not-a-number"}},
+            )
+
+        self.assertEqual(len(snapshot["vehicles"]), 1)
+        self.assertIsNone(snapshot["vehicles"][0]["timestamp"])
+        self.assertIn(f"mbta:trip:{run.id}:timestamp", logs.output[0])
+        self.assertIn(str(run.id), logs.output[0])
+
+    def test_pipeline_length_mismatch_raises(self):
+        first = self._run(run_id=UUID("00000000-0000-0000-0000-000000000001"))
+        second = self._run(run_id=UUID("00000000-0000-0000-0000-000000000002"))
+        incomplete_pipeline_values: list[object] = [
+            [1, 1],
+            {"latitude": "9.93", "longitude": "-84.08"},
+            [None] * 7,
+            [None] * 7,
+        ]
+
+        with (
+            patch(
+                "updates.builders.route.vehicle_positions.VehiclePositionsByRouteSnapshot"
+            ) as snapshot_model,
+            self.assertRaises(ValueError),
+        ):
+            self._snapshot(
+                [first, second],
+                {},
+                pipeline_values=incomplete_pipeline_values,
+            )
+
+        snapshot_model.assert_not_called()

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -16,6 +16,10 @@ from updates.consumers import UpdatesConsumer
 from updates.events import parse_event
 from updates.exceptions import InvalidTopicException
 from updates.planner import process_event
+from updates.projections.route.vehicle_positions import (
+    resolve_vehicle_positions_topics,
+    validate_vehicle_positions_topic,
+)
 from updates.projections.stop.occupancy_status import (
     resolve_stop_occupancy_topics,
 )
@@ -26,7 +30,7 @@ from updates.projections.stop.stop_time_updates import (
 from updates.projections.trip.occupancy_status import (
     resolve_trip_occupancy_topics,
 )
-from updates.registry import projection_for_topic
+from updates.registry import projection_for_topic, projections_for_event
 from updates.schemas import VehiclePositionSnapshot, VehiclePositionsByRouteSnapshot
 from updates.topics import TopicKey
 
@@ -1260,3 +1264,367 @@ class RouteVehiclePositionsBuilderTests(SimpleTestCase):
             )
 
         snapshot_model.assert_not_called()
+
+
+class RouteVehiclePositionsProjectionTests(SimpleTestCase):
+    def test_route_topic_round_trip(self):
+        raw = "mbta.route.vehicle_positions.by_route.route-a"
+
+        topic = TopicKey.parse(raw)
+
+        self.assertEqual(topic.render(), raw)
+        self.assertIsNone(topic.qualifier_selector)
+        self.assertIsNone(topic.qualifier_value)
+
+    def test_validator_rejects_empty_route_id(self):
+        topic = TopicKey(
+            transit_system="mbta",
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            primary_value="",
+        )
+
+        with self.assertRaises(InvalidTopicException):
+            validate_vehicle_positions_topic(topic)
+
+    def test_validator_accepts_populated_route_id(self):
+        topic = TopicKey.parse("mbta.route.vehicle_positions.by_route.route-a")
+
+        self.assertIsNone(validate_vehicle_positions_topic(topic))
+
+    def test_registry_resolves_route_vehicle_positions_topic(self):
+        projection = projection_for_topic(
+            TopicKey.parse("mbta.route.vehicle_positions.by_route.route-a")
+        )
+
+        self.assertIsNotNone(projection)
+        self.assertEqual(projection.name, "route_vehicle_positions")
+        self.assertIs(projection.build, build_route_vehicle_positions)
+
+    def test_registry_lookup_is_unambiguous(self):
+        trip_occupancy = projection_for_topic(
+            TopicKey.parse("mbta.trip.occupancy_status.by_run.run-a")
+        )
+        stop_occupancy = projection_for_topic(
+            TopicKey.parse("mbta.stop.occupancy_status.by_stop.stop-a")
+        )
+        stop_time_updates = projection_for_topic(
+            TopicKey.parse(
+                "mbta.stop.stop_time_updates.by_stop.stop-a.by_direction.1"
+            )
+        )
+
+        self.assertIsNotNone(trip_occupancy)
+        self.assertEqual(trip_occupancy.name, "trip_occupancy_status")
+        self.assertIsNotNone(stop_occupancy)
+        self.assertEqual(stop_occupancy.name, "stop_occupancy_status")
+        self.assertIsNotNone(stop_time_updates)
+        self.assertEqual(stop_time_updates.name, "stop_stop_time_updates")
+
+    @patch("updates.projections.route.vehicle_positions.Run.objects.filter")
+    def test_lifecycle_resolver_returns_route_topic(self, filter_runs):
+        filter_runs.return_value.values_list.return_value.first.return_value = (
+            "route-a"
+        )
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        topics = resolve_vehicle_positions_topics(event)
+
+        self.assertEqual(
+            [topic.render() for topic in topics],
+            ["mbta.route.vehicle_positions.by_route.route-a"],
+        )
+        filter_runs.assert_called_once_with(
+            id=event.run_id,
+            feed_publisher__transit_system__code="mbta",
+        )
+
+    @patch("updates.projections.route.vehicle_positions.Run.objects.filter")
+    def test_lifecycle_resolver_returns_empty_for_missing_run(self, filter_runs):
+        filter_runs.return_value.values_list.return_value.first.return_value = None
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        self.assertEqual(resolve_vehicle_positions_topics(event), [])
+
+    @patch("updates.projections.route.vehicle_positions.Run.objects.filter")
+    def test_lifecycle_resolver_returns_empty_for_run_without_route_id(
+        self,
+        filter_runs,
+    ):
+        first = filter_runs.return_value.values_list.return_value.first
+        first.side_effect = [None, ""]
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        self.assertEqual(resolve_vehicle_positions_topics(event), [])
+        self.assertEqual(resolve_vehicle_positions_topics(event), [])
+
+    def test_lifecycle_event_resolves_both_stop_time_and_vehicle_position(self):
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        projection_names = {
+            projection.name for projection in projections_for_event(event)
+        }
+
+        self.assertIn("stop_stop_time_updates", projection_names)
+        self.assertIn("route_vehicle_positions", projection_names)
+
+
+class ActiveTopicRefreshTests(SimpleTestCase):
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_dispatches_only_route_vehicle_position_topics(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        stop_time = "mbta.stop.stop_time_updates.by_stop.A.by_direction.1"
+        occupancy = "mbta.stop.occupancy_status.by_stop.A"
+        vehicle_positions = "mbta.route.vehicle_positions.by_route.route-a"
+        other_system = "other.route.vehicle_positions.by_route.route-b"
+        active_topics.return_value = {
+            stop_time,
+            occupancy,
+            vehicle_positions,
+            other_system,
+        }
+        stop_time_projection = SimpleNamespace(name="stop_stop_time_updates")
+        occupancy_projection = SimpleNamespace(name="stop_occupancy_status")
+        vehicle_projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.side_effect = lambda topic: {
+            "stop_time_updates": stop_time_projection,
+            "occupancy_status": occupancy_projection,
+            "vehicle_positions": vehicle_projection,
+        }[topic.info]
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 1)
+        vehicle_projection.build.assert_called_once_with(
+            TopicKey.parse(vehicle_positions)
+        )
+        dispatch.assert_called_once_with(
+            TopicKey.parse(vehicle_positions),
+            {"vehicles": []},
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_stop_time_refresh_ignores_route_vehicle_position_topics(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_stop_time_update_topics
+
+        stop_time = "mbta.stop.stop_time_updates.by_stop.A.by_direction.1"
+        vehicle_positions = "mbta.route.vehicle_positions.by_route.route-a"
+        active_topics.return_value = {stop_time, vehicle_positions}
+        stop_time_projection = SimpleNamespace(
+            name="stop_stop_time_updates",
+            validate_topic=Mock(),
+            build=Mock(return_value={"stop_time_updates": []}),
+        )
+        vehicle_projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.side_effect = lambda topic: (
+            stop_time_projection
+            if topic.info == "stop_time_updates"
+            else vehicle_projection
+        )
+
+        count = refresh_active_stop_time_update_topics("mbta")
+
+        self.assertEqual(count, 1)
+        vehicle_projection.build.assert_not_called()
+        dispatch.assert_called_once_with(
+            TopicKey.parse(stop_time),
+            {"stop_time_updates": []},
+        )
+
+    @patch("updates.refresh.active_subscription_topics", return_value=set())
+    def test_stop_time_refresh_log_message_is_unchanged(self, _active_topics):
+        from updates.refresh import refresh_active_stop_time_update_topics
+
+        with self.assertLogs("updates.refresh", level="INFO") as logs:
+            count = refresh_active_stop_time_update_topics("mbta")
+
+        self.assertEqual(count, 0)
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            [
+                "Refreshed 0 active stop-time-update topics for transit system mbta"
+            ],
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=False)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_skips_topic_without_subscribers(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        vehicle_positions = "mbta.route.vehicle_positions.by_route.route-a"
+        active_topics.return_value = {vehicle_positions}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 0)
+        projection.build.assert_not_called()
+        dispatch.assert_not_called()
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_isolates_a_failing_builder(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        broken = "mbta.route.vehicle_positions.by_route.route-a"
+        healthy = "mbta.route.vehicle_positions.by_route.route-b"
+        active_topics.return_value = {broken, healthy}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(side_effect=[RuntimeError("broken builder"), {"ok": True}]),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 1)
+        dispatch.assert_called_once_with(
+            TopicKey.parse(healthy),
+            {"ok": True},
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_applies_projection_validator(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        rejected = "mbta.route.vehicle_positions.by_route.route-a"
+        healthy = "mbta.route.vehicle_positions.by_route.route-b"
+        active_topics.return_value = {rejected, healthy}
+
+        def validate_topic(topic):
+            if topic.primary_value == "route-a":
+                raise InvalidTopicException(topic.render(), "Rejected route.")
+
+        projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(side_effect=validate_topic),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 1)
+        projection.build.assert_called_once_with(TopicKey.parse(healthy))
+        dispatch.assert_called_once_with(
+            TopicKey.parse(healthy),
+            {"vehicles": []},
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_refresh_ignores_malformed_topic_in_active_set(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        malformed = "not-a-valid-topic"
+        healthy = "mbta.route.vehicle_positions.by_route.route-a"
+        active_topics.return_value = {malformed, healthy}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        with self.assertLogs("updates.refresh", level="WARNING") as logs:
+            count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            logs.output,
+            [
+                "WARNING:updates.refresh:Ignoring invalid topic in active "
+                "subscriptions: not-a-valid-topic"
+            ],
+        )
+        dispatch.assert_called_once_with(
+            TopicKey.parse(healthy),
+            {"vehicles": []},
+        )

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -1,9 +1,11 @@
+from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from channels.testing import WebsocketCommunicator
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from runs.events.types import OccupancyStatusChanged
 from runs.events.types import RunCompleted
@@ -275,6 +277,10 @@ class StopTimeUpdatesProjectionTests(SimpleTestCase):
 
     @patch("updates.builders.stop.stop_time_updates._current_documents")
     @patch(
+        "updates.builders.stop.stop_time_updates.timezone.now",
+        return_value=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    @patch(
         "updates.builders.stop.stop_time_updates.run_is_approaching_stop",
         return_value=True,
     )
@@ -287,6 +293,7 @@ class StopTimeUpdatesProjectionTests(SimpleTestCase):
         filter_runs,
         approaching_run_ids,
         _run_is_approaching_stop,
+        _now,
         current_documents,
     ):
         run_a_id = uuid4()
@@ -354,15 +361,319 @@ class StopTimeUpdatesProjectionTests(SimpleTestCase):
         self.assertEqual(snapshot["direction_id"], 1)
         self.assertEqual(
             [update["run_id"] for update in snapshot["stop_time_updates"]],
-            [str(run_b_id), str(run_a_id)],
+            [str(run_a_id), str(run_b_id)],
         )
         self.assertEqual(
             [update["stop_sequence"] for update in snapshot["stop_time_updates"]],
-            [9, 8],
+            [8, 9],
         )
         self.assertEqual(
             snapshot["stop_time_updates"][0]["schedule_relationship"],
             "SCHEDULED",
+        )
+
+
+@override_settings(GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS=120)
+class StopTimeUpdatesBuilderRegressionTests(SimpleTestCase):
+    now_timestamp = 1_800_000_000
+
+    def _run(
+        self,
+        *,
+        route_id: str = "route-a",
+        direction_id: int = 1,
+        transit_system: str = "mbta",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=uuid4(),
+            trip_id=f"trip-{route_id}",
+            route_id=route_id,
+            direction_id=direction_id,
+            feed_publisher=SimpleNamespace(
+                transit_system=SimpleNamespace(code=transit_system)
+            ),
+        )
+
+    def _snapshot(
+        self,
+        runs: list[SimpleNamespace],
+        documents: dict[str, list[dict[str, object]]],
+        *,
+        current_sequences: dict[str, int | None] | None = None,
+        active_ids: set[str] | None = None,
+        candidate_ids: list[str] | None = None,
+        approaching_ids: set[str] | None = None,
+        transit_system: str = "mbta",
+        stop_id: str = "X",
+        direction_id: int = 1,
+    ) -> dict[str, Any]:
+        run_ids = [str(run.id) for run in runs]
+        active_ids = set(run_ids) if active_ids is None else active_ids
+        candidate_ids = run_ids if candidate_ids is None else candidate_ids
+        approaching_ids = (
+            set(candidate_ids) if approaching_ids is None else approaching_ids
+        )
+        current_sequences = current_sequences or {}
+
+        with (
+            patch("updates.builders.stop.stop_time_updates.r") as redis,
+            patch(
+                "updates.builders.stop.stop_time_updates.Run.objects.filter"
+            ) as filter_runs,
+            patch(
+                "updates.builders.stop.stop_time_updates.approaching_run_ids",
+                return_value=candidate_ids,
+            ),
+            patch(
+                "updates.builders.stop.stop_time_updates.run_is_approaching_stop",
+                side_effect=lambda _system, run_id, _stop: (
+                    str(run_id) in approaching_ids
+                ),
+            ),
+            patch(
+                "updates.builders.stop.stop_time_updates._current_documents"
+            ) as current_documents,
+            patch(
+                "updates.builders.stop.stop_time_updates.timezone.now",
+                return_value=datetime.fromtimestamp(self.now_timestamp, tz=UTC),
+            ),
+        ):
+            redis.smembers.return_value = active_ids
+            filter_runs.return_value.select_related.return_value = runs
+            current_documents.side_effect = lambda _system, selected_ids: (
+                [documents.get(run_id, []) for run_id in selected_ids],
+                [current_sequences.get(run_id) for run_id in selected_ids],
+            )
+            topic = TopicKey.parse(
+                f"{transit_system}.stop.stop_time_updates.by_stop.{stop_id}."
+                f"by_direction.{direction_id}"
+            )
+            return build_stop_time_updates(topic)
+
+    def test_active_future_arrival_appears_with_gtfs_fields(self):
+        run = self._run()
+        documents = {
+            str(run.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 4,
+                    "arrival": {
+                        "time": self.now_timestamp + 30,
+                        "delay": 7,
+                        "uncertainty": 3,
+                    },
+                    "departure": {"time": self.now_timestamp + 45},
+                    "schedule_relationship": "SCHEDULED",
+                }
+            ]
+        }
+
+        snapshot = self._snapshot([run], documents)
+
+        update = snapshot["stop_time_updates"][0]
+        self.assertEqual(update["arrival"]["delay"], 7)
+        self.assertEqual(update["arrival"]["uncertainty"], 3)
+        self.assertEqual(update["schedule_relationship"], "SCHEDULED")
+
+    def test_origin_departure_with_null_arrival_appears(self):
+        run = self._run()
+        documents = {
+            str(run.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 1,
+                    "arrival": {"time": None},
+                    "departure": {"time": self.now_timestamp + 30},
+                }
+            ]
+        }
+
+        snapshot = self._snapshot([run], documents)
+
+        update = snapshot["stop_time_updates"][0]
+        self.assertIsNone(update["arrival"]["time"])
+        self.assertEqual(update["departure"]["time"], self.now_timestamp + 30)
+
+    def test_historical_timestamp_is_excluded_but_tolerance_boundary_remains(self):
+        run = self._run()
+        documents = {
+            str(run.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 4,
+                    "arrival": {"time": self.now_timestamp - 121},
+                },
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 5,
+                    "arrival": {"time": self.now_timestamp - 120},
+                },
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 6,
+                    "arrival": {"time": self.now_timestamp - 10},
+                },
+            ]
+        }
+
+        snapshot = self._snapshot([run], documents)
+
+        self.assertEqual(
+            [item["stop_sequence"] for item in snapshot["stop_time_updates"]],
+            [5, 6],
+        )
+
+    def test_noncanonical_approaching_run_is_excluded(self):
+        run = self._run()
+
+        snapshot = self._snapshot(
+            [run],
+            {},
+            active_ids=set(),
+            candidate_ids=[str(run.id)],
+        )
+
+        self.assertEqual(snapshot["stop_time_updates"], [])
+
+    def test_run_whose_stop_was_passed_is_excluded(self):
+        run = self._run()
+
+        snapshot = self._snapshot(
+            [run],
+            {},
+            approaching_ids=set(),
+        )
+
+        self.assertEqual(snapshot["stop_time_updates"], [])
+
+    def test_other_transit_system_is_excluded(self):
+        valid = self._run(route_id="valid")
+        other_system = self._run(route_id="foreign", transit_system="other")
+        documents = {
+            str(run.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 2,
+                    "arrival": {"time": self.now_timestamp + 30},
+                }
+            ]
+            for run in (valid, other_system)
+        }
+
+        snapshot = self._snapshot(
+            [valid, other_system],
+            documents,
+        )
+
+        self.assertEqual(
+            [item["route_id"] for item in snapshot["stop_time_updates"]],
+            ["valid"],
+        )
+
+    def test_other_direction_is_excluded(self):
+        valid = self._run(route_id="valid")
+        other_direction = self._run(route_id="opposite", direction_id=0)
+        documents = {
+            str(run.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 2,
+                    "arrival": {"time": self.now_timestamp + 30},
+                }
+            ]
+            for run in (valid, other_direction)
+        }
+
+        snapshot = self._snapshot([valid, other_direction], documents)
+
+        self.assertEqual(
+            [item["route_id"] for item in snapshot["stop_time_updates"]],
+            ["valid"],
+        )
+
+    def test_multiple_routes_and_repeated_stop_visits_are_preserved(self):
+        first = self._run(route_id="route-a")
+        second = self._run(route_id="route-b")
+        documents = {
+            str(first.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 2,
+                    "arrival": {"time": self.now_timestamp + 20},
+                },
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 8,
+                    "arrival": {"time": self.now_timestamp + 80},
+                },
+            ],
+            str(second.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 3,
+                    "arrival": {"time": self.now_timestamp + 30},
+                }
+            ],
+        }
+
+        snapshot = self._snapshot([first, second], documents)
+
+        self.assertEqual(
+            [item["route_id"] for item in snapshot["stop_time_updates"]],
+            ["route-a", "route-b", "route-a"],
+        )
+        self.assertEqual(
+            [item["stop_sequence"] for item in snapshot["stop_time_updates"]],
+            [2, 3, 8],
+        )
+
+    def test_sorts_by_effective_time_keeps_unknown_last_and_hides_skipped(self):
+        arrival = self._run(route_id="arrival")
+        departure = self._run(route_id="departure")
+        unknown = self._run(route_id="unknown")
+        skipped = self._run(route_id="skipped")
+        documents = {
+            str(arrival.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 2,
+                    "arrival": {"time": self.now_timestamp + 20},
+                }
+            ],
+            str(departure.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 1,
+                    "arrival": {"time": None},
+                    "departure": {"time": self.now_timestamp + 10},
+                }
+            ],
+            str(unknown.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 3,
+                    "arrival": {},
+                    "departure": {},
+                }
+            ],
+            str(skipped.id): [
+                {
+                    "stop_id": "X",
+                    "stop_sequence": 4,
+                    "arrival": {"time": self.now_timestamp + 5},
+                    "schedule_relationship": "SKIPPED",
+                }
+            ],
+        }
+
+        snapshot = self._snapshot(
+            [arrival, departure, unknown, skipped],
+            documents,
+        )
+
+        self.assertEqual(
+            [item["route_id"] for item in snapshot["stop_time_updates"]],
+            ["departure", "arrival", "unknown"],
         )
 
 

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from channels.testing import WebsocketCommunicator
 from django.test import SimpleTestCase, override_settings
+from pydantic import ValidationError
 
 from runs.events.types import OccupancyStatusChanged
 from runs.events.types import RunCompleted
@@ -25,6 +26,7 @@ from updates.projections.trip.occupancy_status import (
     resolve_trip_occupancy_topics,
 )
 from updates.registry import projection_for_topic
+from updates.schemas import VehiclePositionSnapshot, VehiclePositionsByRouteSnapshot
 from updates.topics import TopicKey
 
 
@@ -776,3 +778,102 @@ class PlannerTests(SimpleTestCase):
         projection.resolve_topics.assert_called_once_with(event)
         projection.build.assert_called_once_with(topic)
         dispatch.assert_called_once_with(topic, {"runs": []})
+
+
+class VehiclePositionSchemaTests(SimpleTestCase):
+    def test_vehicle_position_snapshot_accepts_full_payload(self):
+        run_id = uuid4()
+
+        snapshot = VehiclePositionSnapshot(
+            run_id=run_id,
+            trip_id="trip-a",
+            route_id="route-a",
+            direction_id=1,
+            latitude=9.934739,
+            longitude=-84.087502,
+            bearing=180.0,
+            speed=12.5,
+            odometer=5432.1,
+            current_stop_sequence=4,
+            stop_id="stop-a",
+            current_status=2,
+            congestion_level=1,
+            occupancy_status=3,
+            occupancy_percentage=65,
+            timestamp=1_800_000_000,
+        )
+
+        self.assertEqual(snapshot.model_dump(mode="json")["run_id"], str(run_id))
+
+    def test_vehicle_position_snapshot_accepts_null_optional_fields(self):
+        snapshot = VehiclePositionSnapshot(
+            run_id=uuid4(),
+            trip_id=None,
+            route_id="route-a",
+            direction_id=None,
+            latitude=9.934739,
+            longitude=-84.087502,
+            bearing=None,
+            speed=None,
+            odometer=None,
+            current_stop_sequence=None,
+            stop_id=None,
+            current_status=None,
+            congestion_level=None,
+            occupancy_status=None,
+            occupancy_percentage=None,
+            timestamp=None,
+        )
+
+        self.assertIsNone(snapshot.trip_id)
+
+    def test_vehicle_position_snapshot_rejects_unknown_field(self):
+        with self.assertRaises(ValidationError):
+            VehiclePositionSnapshot(
+                run_id=uuid4(),
+                trip_id=None,
+                route_id="route-a",
+                direction_id=None,
+                latitude=9.934739,
+                longitude=-84.087502,
+                bearing=None,
+                speed=None,
+                odometer=None,
+                current_stop_sequence=None,
+                stop_id=None,
+                current_status=None,
+                congestion_level=None,
+                occupancy_status=None,
+                occupancy_percentage=None,
+                timestamp=None,
+                unknown_field="unexpected",
+            )
+
+    def test_vehicle_position_snapshot_requires_coordinates(self):
+        with self.assertRaises(ValidationError):
+            VehiclePositionSnapshot(
+                run_id=uuid4(),
+                trip_id=None,
+                route_id="route-a",
+                direction_id=None,
+                longitude=-84.087502,
+                bearing=None,
+                speed=None,
+                odometer=None,
+                current_stop_sequence=None,
+                stop_id=None,
+                current_status=None,
+                congestion_level=None,
+                occupancy_status=None,
+                occupancy_percentage=None,
+                timestamp=None,
+            )
+
+    def test_vehicle_positions_by_route_snapshot_accepts_empty_vehicle_list(self):
+        snapshot = VehiclePositionsByRouteSnapshot(
+            topic="mbta.route.vehicle_positions.by_route.route-a",
+            route_id="route-a",
+            vehicles=[],
+        )
+
+        self.assertEqual(snapshot.model_dump(mode="json")["vehicles"], [])

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 
 from runs.events.types import OccupancyStatusChanged
 from runs.events.types import RunCompleted
+from updates.builders.stop.stop_time_updates import build_stop_time_updates
 from updates.consumers import UpdatesConsumer
 from updates.events import parse_event
 from updates.exceptions import InvalidTopicException
@@ -14,9 +15,14 @@ from updates.planner import process_event
 from updates.projections.stop.occupancy_status import (
     resolve_stop_occupancy_topics,
 )
+from updates.projections.stop.stop_time_updates import (
+    resolve_stop_time_updates_topics,
+    validate_stop_time_updates_topic,
+)
 from updates.projections.trip.occupancy_status import (
     resolve_trip_occupancy_topics,
 )
+from updates.registry import projection_for_topic
 from updates.topics import TopicKey
 
 
@@ -49,6 +55,15 @@ class TopicKeyTests(SimpleTestCase):
 
         self.assertEqual(context.exception.topic, 123)
         self.assertEqual(context.exception.reason, "A topic must be a string.")
+
+    def test_qualified_topic_round_trip(self):
+        raw = "mbta.stop.stop_time_updates.by_stop.123.by_direction.1"
+
+        topic = TopicKey.parse(raw)
+
+        self.assertEqual(topic.qualifier_selector, "by_direction")
+        self.assertEqual(topic.qualifier_value, "1")
+        self.assertEqual(topic.render(), raw)
 
 
 class UpdatesConsumerTests(SimpleTestCase):
@@ -84,6 +99,30 @@ class UpdatesConsumerTests(SimpleTestCase):
                 "message": "Binary WebSocket messages are not supported.",
             },
         )
+        await communicator.disconnect()
+
+    @patch("updates.consumers.validate_topic")
+    async def test_invalid_projection_value_is_rejected_before_subscribe(
+        self,
+        validate_topic,
+    ):
+        raw_topic = "mbta.stop.stop_time_updates.by_stop.123.by_direction.2"
+        validate_topic.side_effect = InvalidTopicException(
+            raw_topic,
+            "direction_id must be the canonical GTFS value 0 or 1.",
+        )
+        communicator = WebsocketCommunicator(
+            UpdatesConsumer.as_asgi(),
+            "/ws/updates/",
+        )
+        await communicator.connect()
+        await communicator.receive_json_from()
+
+        await communicator.send_json_to({"action": "subscribe", "topic": raw_topic})
+
+        response = await communicator.receive_json_from()
+        self.assertEqual(response["type"], "error")
+        self.assertIn("direction_id", response["message"])
         await communicator.disconnect()
 
 
@@ -164,6 +203,240 @@ class OccupancyProjectionTests(SimpleTestCase):
         self.assertEqual(
             [topic.primary_value for topic in topics],
             ["A", "B"],
+        )
+
+
+class StopTimeUpdatesProjectionTests(SimpleTestCase):
+    def test_registry_resolves_required_qualified_topic(self):
+        projection = projection_for_topic(
+            TopicKey.parse("mbta.stop.stop_time_updates.by_stop.X.by_direction.1")
+        )
+
+        self.assertIsNotNone(projection)
+        self.assertEqual(projection.name, "stop_stop_time_updates")
+
+    def test_rejects_non_gtfs_direction(self):
+        topic = TopicKey.parse("mbta.stop.stop_time_updates.by_stop.X.by_direction.01")
+
+        with self.assertRaises(InvalidTopicException):
+            validate_stop_time_updates_topic(topic)
+
+    @patch("updates.builders.stop.stop_time_updates.Run.objects.filter")
+    @patch(
+        "updates.builders.stop.stop_time_updates.approaching_run_ids",
+        return_value=[],
+    )
+    @patch("updates.builders.stop.stop_time_updates.r")
+    def test_builder_returns_valid_empty_snapshot(
+        self,
+        redis,
+        _approaching_run_ids,
+        filter_runs,
+    ):
+        redis.smembers.return_value = set()
+        filter_runs.return_value.select_related.return_value = []
+        topic = TopicKey.parse(
+            "mbta.stop.stop_time_updates.by_stop.EMPTY.by_direction.1"
+        )
+
+        snapshot = build_stop_time_updates(topic)
+
+        self.assertEqual(snapshot["stop_time_updates"], [])
+        self.assertEqual(snapshot["stop_id"], "EMPTY")
+        self.assertEqual(snapshot["direction_id"], 1)
+
+    @patch("updates.projections.stop.stop_time_updates.Run.objects.filter")
+    def test_lifecycle_resolver_uses_run_direction_and_affected_stops(
+        self,
+        filter_runs,
+    ):
+        filter_runs.return_value.values_list.return_value.first.return_value = 1
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+            affected_stop_ids_json='["A", "B", "A"]',
+        )
+
+        topics = resolve_stop_time_updates_topics(event)
+
+        self.assertEqual(
+            [topic.render() for topic in topics],
+            [
+                "mbta.stop.stop_time_updates.by_stop.A.by_direction.1",
+                "mbta.stop.stop_time_updates.by_stop.B.by_direction.1",
+            ],
+        )
+        filter_runs.assert_called_once_with(
+            id=event.run_id,
+            feed_publisher__transit_system__code="mbta",
+        )
+
+    @patch("updates.builders.stop.stop_time_updates._current_documents")
+    @patch(
+        "updates.builders.stop.stop_time_updates.run_is_approaching_stop",
+        return_value=True,
+    )
+    @patch("updates.builders.stop.stop_time_updates.approaching_run_ids")
+    @patch("updates.builders.stop.stop_time_updates.Run.objects.filter")
+    @patch("updates.builders.stop.stop_time_updates.r")
+    def test_builder_uses_current_state_preserves_visits_and_sorts(
+        self,
+        redis,
+        filter_runs,
+        approaching_run_ids,
+        _run_is_approaching_stop,
+        current_documents,
+    ):
+        run_a_id = uuid4()
+        run_b_id = uuid4()
+        transit_system = SimpleNamespace(code="mbta")
+        publisher = SimpleNamespace(transit_system=transit_system)
+        run_a = SimpleNamespace(
+            id=run_a_id,
+            trip_id="trip-a",
+            route_id="route-a",
+            direction_id=1,
+            feed_publisher=publisher,
+        )
+        run_b = SimpleNamespace(
+            id=run_b_id,
+            trip_id="trip-b",
+            route_id="route-b",
+            direction_id=1,
+            feed_publisher=publisher,
+        )
+        filter_runs.return_value.select_related.return_value = [run_a, run_b]
+        approaching_run_ids.return_value = [str(run_a_id), str(run_b_id)]
+        redis.smembers.return_value = {str(run_a_id), str(run_b_id)}
+        current_documents.return_value = (
+            [
+                [
+                    {
+                        "stop_id": "X",
+                        "stop_sequence": 8,
+                        "arrival": {},
+                        "departure": {"time": 100},
+                        "schedule_relationship": "SCHEDULED",
+                    }
+                ],
+                [
+                    {
+                        "stop_id": "X",
+                        "stop_sequence": 4,
+                        "arrival": {"time": 50},
+                        "departure": {},
+                    },
+                    {
+                        "stop_id": "X",
+                        "stop_sequence": 9,
+                        "arrival": {"time": 200, "delay": 5},
+                        "departure": {},
+                        "schedule_relationship": 0,
+                    },
+                    {
+                        "stop_id": "X",
+                        "stop_sequence": 10,
+                        "arrival": {"time": 300},
+                        "departure": {},
+                        "schedule_relationship": "SKIPPED",
+                    },
+                ],
+            ],
+            [None, 5],
+        )
+        topic = TopicKey.parse("mbta.stop.stop_time_updates.by_stop.X.by_direction.1")
+
+        snapshot = build_stop_time_updates(topic)
+
+        self.assertEqual(snapshot["topic"], topic.render())
+        self.assertEqual(snapshot["direction_id"], 1)
+        self.assertEqual(
+            [update["run_id"] for update in snapshot["stop_time_updates"]],
+            [str(run_b_id), str(run_a_id)],
+        )
+        self.assertEqual(
+            [update["stop_sequence"] for update in snapshot["stop_time_updates"]],
+            [9, 8],
+        )
+        self.assertEqual(
+            snapshot["stop_time_updates"][0]["schedule_relationship"],
+            "SCHEDULED",
+        )
+
+
+class PollRefreshTests(SimpleTestCase):
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers")
+    @patch("updates.refresh.active_subscription_topics")
+    def test_refreshes_only_active_matching_topics_with_subscribers(
+        self,
+        active_topics,
+        has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_stop_time_update_topics
+
+        direction_zero = "mbta.stop.stop_time_updates.by_stop.A.by_direction.0"
+        direction_one = "mbta.stop.stop_time_updates.by_stop.A.by_direction.1"
+        active_topics.return_value = {
+            direction_zero,
+            direction_one,
+            "mbta.stop.occupancy_status.by_stop.A",
+            "other.stop.stop_time_updates.by_stop.A.by_direction.1",
+        }
+        has_subscribers.side_effect = lambda _redis, topic: topic == direction_one
+        projection = SimpleNamespace(
+            name="stop_stop_time_updates",
+            validate_topic=Mock(),
+            build=Mock(return_value={"stop_time_updates": []}),
+        )
+        occupancy_projection = SimpleNamespace(name="stop_occupancy_status")
+        projection_for_topic_mock.side_effect = lambda topic: (
+            occupancy_projection if topic.info == "occupancy_status" else projection
+        )
+
+        count = refresh_active_stop_time_update_topics("mbta")
+
+        self.assertEqual(count, 1)
+        projection.build.assert_called_once_with(TopicKey.parse(direction_one))
+        dispatch.assert_called_once_with(
+            TopicKey.parse(direction_one),
+            {"stop_time_updates": []},
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_one_broken_topic_does_not_block_other_refreshes(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_stop_time_update_topics
+
+        broken = "mbta.stop.stop_time_updates.by_stop.A.by_direction.1"
+        healthy = "mbta.stop.stop_time_updates.by_stop.B.by_direction.1"
+        active_topics.return_value = {broken, healthy}
+        projection = SimpleNamespace(
+            name="stop_stop_time_updates",
+            validate_topic=Mock(),
+            build=Mock(side_effect=[RuntimeError("broken builder"), {"ok": True}]),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_stop_time_update_topics("mbta")
+
+        self.assertEqual(count, 1)
+        dispatch.assert_called_once_with(
+            TopicKey.parse(healthy),
+            {"ok": True},
         )
 
 

--- a/backend/website/templates/updates.html
+++ b/backend/website/templates/updates.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>MBTA occupancy stream | Infobús</title>
+		<title>WebSocket updates console | Infobús</title>
 		<style>
 			:root {
 				color-scheme: light;
@@ -17,9 +17,7 @@
 				--connected: #087f5b;
 			}
 
-			* {
-				box-sizing: border-box;
-			}
+			* { box-sizing: border-box; }
 
 			body {
 				margin: 0;
@@ -54,14 +52,13 @@
 				font-size: clamp(2rem, 5vw, 4rem);
 				font-weight: 500;
 				line-height: 0.95;
-				letter-spacing: 0;
 			}
 
 			.system-mark {
+				margin-bottom: 8px;
 				color: var(--accent);
 				font-size: 0.8rem;
 				font-weight: 700;
-				letter-spacing: 0;
 				text-transform: uppercase;
 			}
 
@@ -82,22 +79,19 @@
 				content: "";
 			}
 
-			.status[data-state="connected"]::before {
-				background: var(--connected);
-			}
-
-			.status[data-state="connecting"]::before {
-				background: #e59f00;
-			}
+			.status[data-state="connected"]::before { background: var(--connected); }
+			.status[data-state="connecting"]::before { background: #e59f00; }
 
 			.controls {
 				display: grid;
-				grid-template-columns: minmax(0, 1fr) auto;
-				gap: 12px;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				gap: 16px;
 				padding: 28px 0 20px;
 			}
 
-			label {
+			#parameter-fields { display: contents; }
+
+			.field label {
 				display: block;
 				margin-bottom: 7px;
 				color: var(--muted);
@@ -106,15 +100,14 @@
 				text-transform: uppercase;
 			}
 
-			select,
-			button {
+			select, input, button {
 				min-height: 48px;
 				border: 1px solid var(--line);
 				border-radius: 4px;
 				font: inherit;
 			}
 
-			select {
+			select, input {
 				width: 100%;
 				padding: 0 14px;
 				background: var(--surface);
@@ -122,7 +115,6 @@
 			}
 
 			button {
-				align-self: end;
 				padding: 0 22px;
 				border-color: var(--accent);
 				background: var(--accent);
@@ -131,13 +123,13 @@
 				font-weight: 700;
 			}
 
-			button:hover:not(:disabled) {
-				background: var(--accent-dark);
-			}
+			button:hover:not(:disabled) { background: var(--accent-dark); }
+			button:disabled { cursor: not-allowed; opacity: 0.45; }
 
-			button:disabled {
-				cursor: not-allowed;
-				opacity: 0.45;
+			.connect-row {
+				display: flex;
+				justify-content: flex-end;
+				margin: 0 0 20px;
 			}
 
 			.topic {
@@ -196,27 +188,10 @@
 			}
 
 			@media (max-width: 640px) {
-				main {
-					width: min(100% - 20px, 1080px);
-					padding: 28px 0;
-				}
-
-				header {
-					align-items: start;
-					flex-direction: column;
-				}
-
-				.controls {
-					grid-template-columns: 1fr;
-				}
-
-				button {
-					width: 100%;
-				}
-
-				.clear-button {
-					width: auto;
-				}
+				main { width: min(100% - 20px, 1080px); padding: 28px 0; }
+				header { align-items: start; flex-direction: column; }
+				.controls { grid-template-columns: 1fr; }
+				.connect-row button { width: 100%; }
 			}
 		</style>
 	</head>
@@ -224,8 +199,8 @@
 		<main>
 			<header>
 				<div>
-					<div class="system-mark">{{ transit_system }} real-time</div>
-					<h1>Stop occupancy</h1>
+					<div class="system-mark">Infobús development tool</div>
+					<h1>Updates console</h1>
 				</div>
 				<div id="connection-status" class="status" data-state="disconnected">
 					Disconnected
@@ -233,36 +208,39 @@
 			</header>
 
 			<section class="controls" aria-label="Subscription controls">
-				<div>
-					<label for="stop-select">Stop</label>
-					<select id="stop-select">
-						<option value="">Select a stop</option>
-						{% for stop in stops %}
-							<option value="{{ stop.stop_id }}">
-								{{ stop.stop_name|default:stop.stop_id }} — {{ stop.stop_id }}
-							</option>
-						{% endfor %}
-					</select>
+				<div class="field">
+					<label for="system-select">Transit system</label>
+					<select id="system-select"></select>
 				</div>
-				<button id="connect-button" type="button" disabled>Connect</button>
+				<div class="field">
+					<label for="projection-select">Projection</label>
+					<select id="projection-select"></select>
+				</div>
+				<div id="parameter-fields"></div>
 			</section>
 
 			<p id="topic" class="topic">No topic selected</p>
+			<div class="connect-row">
+				<button id="connect-button" type="button" disabled>Connect &amp; subscribe</button>
+			</div>
 
 			<section class="stream" aria-label="Raw WebSocket messages">
 				<div class="stream-header">
 					<span>Raw WebSocket messages</span>
-					<button id="clear-button" class="clear-button" type="button">
-						Clear
-					</button>
+					<button id="clear-button" class="clear-button" type="button">Clear</button>
 				</div>
 				<pre id="messages" aria-live="polite"></pre>
 			</section>
 		</main>
 
+		{{ projection_metadata|json_script:"projection-data" }}
+		{{ transit_systems|json_script:"transit-system-data" }}
 		<script>
-			const transitSystem = "{{ transit_system|escapejs }}";
-			const stopSelect = document.querySelector("#stop-select");
+			const projections = JSON.parse(document.querySelector("#projection-data").textContent);
+			const transitSystems = JSON.parse(document.querySelector("#transit-system-data").textContent);
+			const systemSelect = document.querySelector("#system-select");
+			const projectionSelect = document.querySelector("#projection-select");
+			const parameterFields = document.querySelector("#parameter-fields");
 			const connectButton = document.querySelector("#connect-button");
 			const clearButton = document.querySelector("#clear-button");
 			const statusElement = document.querySelector("#connection-status");
@@ -270,9 +248,93 @@
 			const messagesElement = document.querySelector("#messages");
 			let socket = null;
 
+			function addOption(select, value, label) {
+				const option = document.createElement("option");
+				option.value = value;
+				option.textContent = label;
+				select.append(option);
+			}
+
+			function selectedProjection() {
+				return projections.find((projection) => projection.name === projectionSelect.value) || null;
+			}
+
+			function selectedSystem() {
+				return transitSystems.find((system) => system.code === systemSelect.value) || null;
+			}
+
+			function renderParameterFields() {
+				parameterFields.replaceChildren();
+				const projection = selectedProjection();
+				if (!projection) return;
+
+				for (const parameter of projection.parameters) {
+					const field = document.createElement("div");
+					field.className = "field";
+					const label = document.createElement("label");
+					label.htmlFor = `parameter-${parameter.name}`;
+					label.textContent = parameter.label;
+					let input;
+
+					if (parameter.input === "select") {
+						input = document.createElement("select");
+						addOption(input, "", `Select ${parameter.label.toLowerCase()}`);
+						if (parameter.data_source === "current_stops") {
+							for (const stop of selectedSystem()?.stops || []) {
+								addOption(input, stop.stop_id, `${stop.stop_name} — ${stop.stop_id}`);
+							}
+						} else {
+							for (const choice of parameter.choices || []) {
+								addOption(input, choice.value, choice.label);
+							}
+						}
+					} else {
+						input = document.createElement("input");
+						input.type = "text";
+						input.placeholder = parameter.name;
+					}
+
+					input.id = `parameter-${parameter.name}`;
+					input.dataset.parameter = parameter.name;
+					input.addEventListener("input", updateTopic);
+					input.addEventListener("change", updateTopic);
+					field.append(label, input);
+					parameterFields.append(field);
+				}
+			}
+
 			function selectedTopic() {
-				if (!stopSelect.value) return null;
-				return `${transitSystem}.stop.occupancy_status.by_stop.${stopSelect.value}`;
+				const projection = selectedProjection();
+				if (!projection || !systemSelect.value) return null;
+				const values = new Map(
+					[...parameterFields.querySelectorAll("[data-parameter]")].map((input) => [input.dataset.parameter, input.value])
+				);
+				if (projection.parameters.some((parameter) => !values.get(parameter.name))) return null;
+
+				const primaryName = projection.parameters.find(
+					(parameter) => parameter.selector === projection.primary_selector
+				).name;
+				const segments = [
+					systemSelect.value,
+					projection.entity,
+					projection.info,
+					projection.primary_selector,
+					values.get(primaryName),
+				];
+				if (projection.qualifier_selector) {
+					const qualifierName = projection.parameters.find(
+						(parameter) => parameter.selector === projection.qualifier_selector
+					).name;
+					segments.push(projection.qualifier_selector, values.get(qualifierName));
+				}
+				return segments.join(".");
+			}
+
+			function updateTopic() {
+				const topic = selectedTopic();
+				topicElement.textContent = topic || "No topic selected";
+				connectButton.disabled = !topic;
+				connectButton.textContent = socket ? "Switch topic" : "Connect & subscribe";
 			}
 
 			function setStatus(state, label) {
@@ -281,69 +343,68 @@
 			}
 
 			function appendMessage(message) {
-				const lines = messagesElement.textContent
-					? messagesElement.textContent.split("\n\n")
-					: [];
+				const lines = messagesElement.textContent ? messagesElement.textContent.split("\n\n") : [];
 				lines.push(message);
 				messagesElement.textContent = lines.slice(-200).join("\n\n");
 				messagesElement.scrollTop = messagesElement.scrollHeight;
 			}
 
 			function disconnect() {
-				if (socket) {
-					socket.onclose = null;
-					socket.close();
-					socket = null;
-				}
+				if (!socket) return;
+				const previousSocket = socket;
+				socket = null;
+				previousSocket.close();
 			}
 
 			function connect() {
 				const topic = selectedTopic();
 				if (!topic) return;
-
 				disconnect();
-				messagesElement.textContent = "";
 				setStatus("connecting", "Connecting");
 				connectButton.disabled = true;
-
 				const scheme = window.location.protocol === "https:" ? "wss" : "ws";
-				socket = new WebSocket(`${scheme}://${window.location.host}/ws/updates/`);
+				const nextSocket = new WebSocket(`${scheme}://${window.location.host}/ws/updates/`);
+				socket = nextSocket;
 
-				socket.addEventListener("open", () => {
-					socket.send(JSON.stringify({ action: "subscribe", topic }));
+				nextSocket.addEventListener("open", () => {
+					if (socket !== nextSocket) return;
+					nextSocket.send(JSON.stringify({ action: "subscribe", topic }));
 					setStatus("connected", "Connected");
 					connectButton.disabled = false;
 					connectButton.textContent = "Reconnect";
 				});
-
-				socket.addEventListener("message", (event) => {
-					appendMessage(event.data);
+				nextSocket.addEventListener("message", (event) => {
+					if (socket === nextSocket) appendMessage(event.data);
 				});
-
-				socket.addEventListener("error", () => {
+				nextSocket.addEventListener("error", () => {
+					if (socket !== nextSocket) return;
 					setStatus("disconnected", "Connection error");
 					connectButton.disabled = false;
 				});
-
-				socket.addEventListener("close", () => {
+				nextSocket.addEventListener("close", () => {
+					if (socket !== nextSocket) return;
 					socket = null;
 					setStatus("disconnected", "Disconnected");
-					connectButton.disabled = !stopSelect.value;
-					connectButton.textContent = "Connect";
+					connectButton.disabled = !selectedTopic();
+					connectButton.textContent = "Connect & subscribe";
 				});
 			}
 
-			stopSelect.addEventListener("change", () => {
-				const topic = selectedTopic();
-				topicElement.textContent = topic || "No topic selected";
-				connectButton.disabled = !topic;
-				connectButton.textContent = socket ? "Switch stop" : "Connect";
-			});
+			addOption(systemSelect, "", "Select a transit system");
+			for (const system of transitSystems) addOption(systemSelect, system.code, `${system.name} — ${system.code}`);
+			addOption(projectionSelect, "", "Select a projection");
+			for (const projection of projections) addOption(projectionSelect, projection.name, projection.name);
 
-			connectButton.addEventListener("click", connect);
-			clearButton.addEventListener("click", () => {
-				messagesElement.textContent = "";
+			systemSelect.addEventListener("change", () => {
+				renderParameterFields();
+				updateTopic();
 			});
+			projectionSelect.addEventListener("change", () => {
+				renderParameterFields();
+				updateTopic();
+			});
+			connectButton.addEventListener("click", connect);
+			clearButton.addEventListener("click", () => { messagesElement.textContent = ""; });
 			window.addEventListener("beforeunload", disconnect);
 		</script>
 	</body>

--- a/backend/website/tests.py
+++ b/backend/website/tests.py
@@ -3,23 +3,56 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 from django.urls import reverse
 
+from website.views import _projection_metadata
+
 
 class UpdatesPageTests(SimpleTestCase):
-    @patch("website.views.Stop.objects.filter")
-    def test_renders_mbta_stops(self, filter_stops):
-        filter_stops.return_value.exclude.return_value.order_by.return_value.values.return_value.distinct.return_value = [
-            {"stop_id": "123", "stop_name": "Test Stop"}
+    @patch("website.views._current_schedule_systems")
+    def test_renders_registry_driven_console(self, current_schedule_systems):
+        current_schedule_systems.return_value = [
+            {
+                "code": "mbta",
+                "name": "MBTA",
+                "stops": [{"stop_id": "123", "stop_name": "Test Stop"}],
+            }
         ]
 
         response = self.client.get(reverse("updates_test"))
 
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Updates console")
         self.assertContains(response, "Test Stop")
-        self.assertContains(
-            response,
-            "${transitSystem}.stop.occupancy_status.by_stop.${stopSelect.value}",
+        self.assertContains(response, "stop_stop_time_updates")
+        self.assertContains(response, "/ws/updates/")
+        self.assertContains(response, "projection.primary_selector")
+
+    def test_stop_time_projection_metadata_includes_both_parameters(self):
+        from updates.registry import PROJECTIONS
+
+        projection = next(
+            projection
+            for projection in PROJECTIONS
+            if projection.name == "stop_stop_time_updates"
         )
-        filter_stops.assert_called_once_with(
-            feed__is_current=True,
-            feed__feed_publisher__transit_system__code="mbta",
+
+        metadata = _projection_metadata(projection)
+
+        self.assertEqual(
+            [parameter["name"] for parameter in metadata["parameters"]],
+            ["stop_id", "direction_id"],
         )
+        self.assertEqual(metadata["qualifier_selector"], "by_direction")
+
+    def test_existing_stop_occupancy_is_exposed_from_registry(self):
+        from updates.registry import PROJECTIONS
+
+        projection = next(
+            projection
+            for projection in PROJECTIONS
+            if projection.name == "stop_occupancy_status"
+        )
+
+        metadata = _projection_metadata(projection)
+
+        self.assertEqual(metadata["info"], "occupancy_status")
+        self.assertEqual(metadata["primary_selector"], "by_stop")

--- a/backend/website/views.py
+++ b/backend/website/views.py
@@ -1,6 +1,21 @@
+from typing import TypedDict
+
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
-from feed.models import Stop
+from feed.models import Feed, Stop
+from updates.registry import PROJECTIONS, ProjectionSpec
+
+
+class StopOption(TypedDict):
+    stop_id: str
+    stop_name: str
+
+
+class TransitSystemOption(TypedDict):
+    code: str
+    name: str
+    stops: list[StopOption]
+
 
 # Create your views here.
 
@@ -20,23 +35,113 @@ def profile(request: HttpRequest) -> HttpResponse:
     return render(request, "profile.html")
 
 
-def updates(request: HttpRequest) -> HttpResponse:
-    """Render the update viewer with distinct current MBTA stops."""
-    stops = (
-        Stop.objects.filter(
-            feed__is_current=True,
-            feed__feed_publisher__transit_system__code="mbta",
+def _parameter_metadata(selector: str) -> dict[str, object]:
+    """Describe a selector as JSON-safe console input metadata."""
+    name = f"{selector.removeprefix('by_')}_id"
+    metadata: dict[str, object] = {
+        "name": name,
+        "selector": selector,
+        "label": name.replace("_", " ").title(),
+        "input": "text",
+    }
+    if selector == "by_stop":
+        metadata.update({"input": "select", "data_source": "current_stops"})
+    elif selector == "by_direction":
+        metadata.update(
+            {
+                "input": "select",
+                "choices": [
+                    {"value": "0", "label": "0"},
+                    {"value": "1", "label": "1"},
+                ],
+            }
         )
-        .exclude(stop_id="")
-        .order_by("stop_name", "stop_id")
-        .values("stop_id", "stop_name")
+    return metadata
+
+
+def _projection_metadata(projection: ProjectionSpec) -> dict[str, object]:
+    """Expose only JSON-safe topic structure derived from one registry entry."""
+    pattern = projection.topic_pattern
+    parameters = [_parameter_metadata(pattern.primary_selector)]
+    if pattern.qualifier_selector is not None:
+        parameters.append(_parameter_metadata(pattern.qualifier_selector))
+    return {
+        "name": projection.name,
+        "description": projection.description,
+        "entity": pattern.entity,
+        "info": pattern.info,
+        "primary_selector": pattern.primary_selector,
+        "qualifier_selector": pattern.qualifier_selector,
+        "parameters": parameters,
+    }
+
+
+def _current_schedule_systems() -> list[TransitSystemOption]:
+    """Return systems with a current Schedule feed and their distinct stops."""
+    system_rows = (
+        Feed.objects.filter(
+            is_current=True,
+            feed_publisher__transit_system__isnull=False,
+        )
+        .values(
+            "feed_publisher__transit_system__code",
+            "feed_publisher__transit_system__name",
+        )
+        .order_by("feed_publisher__transit_system__name")
         .distinct()
     )
+    systems: list[TransitSystemOption] = [
+        {
+            "code": row["feed_publisher__transit_system__code"],
+            "name": row["feed_publisher__transit_system__name"],
+            "stops": [],
+        }
+        for row in system_rows
+    ]
+    systems_by_code: dict[str, TransitSystemOption] = {
+        system["code"]: system for system in systems
+    }
+    seen_stop_ids: dict[str, set[str]] = {code: set() for code in systems_by_code}
+
+    stop_rows = (
+        Stop.objects.filter(
+            feed__is_current=True,
+            feed__feed_publisher__transit_system__code__in=systems_by_code,
+        )
+        .exclude(stop_id="")
+        .values(
+            "feed__feed_publisher__transit_system__code",
+            "stop_id",
+            "stop_name",
+        )
+        .order_by(
+            "feed__feed_publisher__transit_system__code",
+            "stop_name",
+            "stop_id",
+        )
+        .distinct()
+    )
+    for row in stop_rows:
+        code = str(row["feed__feed_publisher__transit_system__code"])
+        stop_id = str(row["stop_id"])
+        if code not in systems_by_code or stop_id in seen_stop_ids[code]:
+            continue
+        seen_stop_ids[code].add(stop_id)
+        systems_by_code[code]["stops"].append(
+            {"stop_id": stop_id, "stop_name": row["stop_name"] or stop_id}
+        )
+    return systems
+
+
+def updates(request: HttpRequest) -> HttpResponse:
+    """Render the registry-driven manual WebSocket update console."""
     return render(
         request,
         "updates.html",
         {
-            "stops": stops,
-            "transit_system": "mbta",
+            "projection_metadata": [
+                _projection_metadata(projection) for projection in PROJECTIONS
+            ],
+            "transit_systems": _current_schedule_systems(),
         },
     )


### PR DESCRIPTION
## Summary

This branch adds two registered WebSocket projections: stop-time predictions grouped by stop and GTFS direction, and vehicle positions grouped by route. Both projections expose complete current snapshots  so a new subscriber and an existing subscriber receive the same payload shape.

The builders combine persisted Run metadata with the canonical Redis active-run set and current GTFS Realtime state. Successful TripUpdates and VehiclePositions polls refresh matching active subscriptions once per transit system, while run lifecycle events rebuild affected topics through the existing Redis Stream planner.

## What's included

### Stop-time updates by stop and direction

Topic:

```
<transit_system>.stop.stop_time_updates.by_stop.<stop_id>.by_direction.<direction_id>
```

`direction_id` must be the canonical string `0` or `1`; values such as `01`, missing values, and empty stop IDs are rejected before subscription state is changed.

The payload contains `topic`, `stop_id`, `direction_id`, and `stop_time_updates`. Each visit contains `run_id`, nullable `trip_id` and `route_id`, `direction_id`, `stop_id`, nullable `stop_sequence`, arrival and departure objects (`delay`, `time`, and `uncertainty`), and nullable `schedule_relationship`.

The builder intersects the stop's approaching-run index with the transit system's canonical active-run set, rechecks each run's remaining-stop index, scopes Run rows to the transit system and requested direction, and bulk-reads prediction documents and current stop sequences. It then removes entries for another stop, malformed or passed sequences, schema-invalid entries, SKIPPED visits, and predictions older than the configured tolerance. Predictions without an arrival or departure time remain eligible. Results are ordered by arrival time, falling back to departure time, with unknown times last and deterministic run/sequence tie-breakers. An empty result is returned as a valid snapshot.

Active subscriptions are refreshed after successful TripUpdates polls. Signal loss, signal restoration, completion, interruption, and cancellation also invalidate the affected stop/direction topics by using stop IDs captured before lifecycle cleanup.

### Vehicle positions by route

Topic:

```
<transit_system>.route.vehicle_positions.by_route.<route_id>
```

An empty `route_id` is rejected before subscription state is changed.

The payload contains `topic`, `route_id`, and `vehicles`. Each vehicle contains `run_id`, nullable `trip_id`, `route_id`, nullable `direction_id`, required `latitude` and `longitude`, nullable `bearing`, `speed`, `odometer`, `current_stop_sequence`, `stop_id`, `current_status`, `congestion_level`, `occupancy_status`, `occupancy_percentage`, and `timestamp`.

The builder first selects Run rows for the requested route and transit system whose database lifecycle state is active. It intersects those rows with the canonical Redis active-run set and reads all position hashes and scalar state through one non-transactional pipeline. Runs absent from the active set, positions without parseable coordinates, and positions with a timestamp older than the configured tolerance are excluded. Missing timestamps remain eligible, malformed optional numeric values are logged and exposed as null, vehicles are sorted by textual `run_id`, and an empty result is returned as a valid snapshot.

Active subscriptions are refreshed after successful VehiclePositions polls. The same five lifecycle event types resolve the affected run's current route and rebuild that route topic.

## Shared changes

`ProjectionSpec` now supports an optional semantic validator. The WebSocket consumer applies registry and projection validation before joining the Channels group or recording subscription metadata.

`updates/refresh.py` now routes both poll-driven refresh paths through `_refresh_active_topics(transit_system, projection_name, log_label)`. The helper filters active subscription metadata by transit system and projection, verifies subscriber presence before collection and again before building, applies topic validation, dispatches complete snapshots, and isolates failures per topic. The existing stop-time wrapper still supplies `stop_stop_time_updates` and `stop-time-update`; its topic selection, validation, build/dispatch flow, failure isolation, return value, and log text are unchanged. Regression tests assert that route topics are ignored by the stop-time refresh and that its log message is retained.

Run confirmation now exposes the Run record to state ingestion so terminal runs cannot repopulate realtime state. TripUpdate serialization preserves protobuf field presence and schedule-relationship names. Terminal cleanup uses a bounded list of known keys instead of a global scan, leaves a terminal initialization marker to prevent stop-index reconstruction, captures affected stops before removing index memberships, and publishes lifecycle events after leaving the per-run lock while remaining commit-safe. Lifecycle evaluation also uses a renewable lock to avoid overlapping scans.

The manual updates page now derives projection choices from `PROJECTIONS` and lists stops for every transit system with a current schedule feed instead of hard-coding one system and one topic.

## Configuration

| Setting | Default | Purpose |
|---|---|---|
| `RUN_LIFECYCLE_EVALUATION_LOCK_SECONDS` | 120 | TTL for the renewable lock that prevents overlapping lifecycle evaluations. |
| `GTFS_RT_STOP_TIME_UPDATE_PAST_TOLERANCE_SECONDS` | 120 | Maximum age, in seconds, for a stop prediction that has an event timestamp. |
| `GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS` | 120 | Maximum age, in seconds, for a vehicle position that has a timestamp. |

All three settings have defaults and do not require environment changes for the existing behavior.

## Testing

The range adds 69 test methods: 52 in `updates`, 8 in `engine`, 6 in `runs`, and 3 in `website`.

Executed in the development orchestrator container (Python 3.14.7):

- `python manage.py test updates -v 2`: 63 passed.
- `python manage.py test engine -v 2`: 8 passed.
- `python manage.py test runs -v 2`: 12 passed.
- `python manage.py test website -v 2`: 3 passed.

The error-level messages emitted by the updates and engine runs came from tests that deliberately inject builder, validator, refresh, and HTTP failures; those cases completed with ok and all suites exited successfully.

A read-only operational spot check was also run on August 18, 2026 against the current development PostgreSQL and Redis state. `2.route.vehicle_positions.by_route.69` produced a Pydantic-valid snapshot with 4 vehicles, and `2.stop.stop_time_updates.by_stop.70500.by_direction.0` produced a Pydantic-valid snapshot with 8 visits. These counts are point-in-time observations from mutable feed state, not deterministic test expectations or a substitute for an automated integration test.

A second read-only cross-check against the current MBTA VehiclePositions feed found 28 `Shuttle-Generic` entities. Twenty-seven resolved to terminal Run records and were absent from the canonical Redis active-run set; the remaining entity had a stored Redis timestamp older than the configured tolerance. The route snapshot was therefore empty. This current observation confirms that the canonical-set intersection removes real feed entities, including a majority on an observed route, rather than covering only a synthetic edge case. The exact distribution is feed-dependent and can change between polls.

In an earlier end-to-end validation session for a different queried route, the MBTA feed contained 21 entities: 15 resolved to terminal runs absent from the canonical Redis set, 4 had timestamps older than the configured tolerance, and the remaining 2 matched the published snapshot exactly. Consecutive WebSocket messages arrived 29.978 s, 29.974 s, and 29.925 s apart. These exact counts and intervals are historical observations from that earlier session; they were not reproduced during this review and should not be treated as deterministic assertions.

## Known limitations

- `Run.route_id` has no declared database index. The route builder filters on this field for every requested route.
- GTFS `route_id` values are unique within a feed file, while this topic is scoped only by transit system and raw `route_id`. Identical route IDs from different publishers in the same transit system are intentionally aggregated.
- Topic parsing splits on `.` and accepts exactly five or seven segments. A `route_id` containing a dot cannot be represented by this route topic; the same grammar constraint applies to other identifier-valued segments.
- Position hashes are updated incrementally with `HSET`. A field omitted by a later VehiclePosition message is not deleted, so an older hash value can remain visible until terminal-state cleanup expires the key.
- GTFS Realtime `TripDescriptor.direction_id` may be absent. Such a run is excluded from the stop-time topic because that topic requires direction 0 or 1; the route payload can expose `direction_id: null`.
- The payloads do not resolve rider-facing `route_short_name`, stop names, or `trip_headsign`; they expose identifiers and realtime state only.
- Neither the position-hash write nor the stop-time prediction-document write emits a projection-specific typed change event. Poll refresh is the regular near-real-time delivery path for those changes. Initial subscription snapshots and lifecycle-triggered rebuilds remain separate delivery paths.
- Vehicle positions without a timestamp and stop-time visits without a predicted event time remain eligible, so the configured age tolerances cannot reject them.
- The stop-time RedisJSON document and remaining-stop indexes are written in separate Redis operations; a concurrent build can observe an intermediate combination.
- Default pytest discovery does not collect Django app files named `tests.py`; a collection check found only 18 tests from the `gtfs-django` and `gtfs-io` subpackages. The app suites currently require explicit `manage.py test` invocation.
- The only GitHub Actions workflow deploys documentation and does not run tests.
- The project runs in the container on Python 3.14.7 and satisfies `requires-python >=3.14`. Because there is no `[tool.ruff]` section with an explicit target, Ruff infers target version 3.14 from the project metadata. With that target, `ruff format` rewrites parenthesized multi-exception handlers to PEP 758 syntax such as `except TypeError, ValueError:`, which Python 3.13 and earlier cannot parse. Auxiliary tools that use an older Python parser therefore require the parenthesized form or an explicit formatting policy.
- Per-topic failure isolation is implemented for poll refreshes. Initial subscription builds and lifecycle processing through the planner do not isolate builder/dispatcher failures at the same boundary.

## Out of scope

This PR does not add a `route_id` migration or index, change route identity to include the publisher, introduce escaping for topic segments, enrich snapshots from schedule Route, Trip, or Stop records, add projection-specific position/prediction events, or change pytest/CI configuration.

## Review notes

The long-form `backend/updates/README.md` still contains older statements that only occupancy has event-driven projections and that the manual console is MBTA-specific, while later sections document the new projections and registry-driven console. Those statements should be reconciled during review or in a follow-up documentation change.

The supporting scope is intentional and part of the feature: the branch also hardens terminal-run lifecycle handling, captures affected stops before cleanup, adds projection-specific topic validation, and makes the manual updates console derive its inputs from the projection registry and current schedule data.