### PR TITLE
Feature/vehicle position direction

### DIFF
--- a/backend/updates/README.md
+++ b/backend/updates/README.md
@@ -1539,6 +1539,13 @@ and `by_route` comes from the registry.
 (`backend/updates/projections/route/vehicle_positions.py:8-11`,
 `backend/updates/registry.py:120-124`)
 
+> Verification note: this five-segment topic still has no qualifier, and the statement
+> above remains accurate for it. A separate qualified projection now serves the
+> seven-segment variant documented below; the two patterns are disjoint because
+> `TopicPattern.matches()` compares `qualifier_selector` by exact equality, including
+> `None`. (`backend/updates/topics.py:81-88`,
+> `backend/updates/registry.py:141-163`)
+
 ### Run resolution and snapshot construction
 
 The builder first queries PostgreSQL for `Run` rows whose `route_id` matches the
@@ -1648,5 +1655,146 @@ fields from `Run` and performs no Schedule `Route` or `Trip` lookup.
   `backend/runs/services/state.py:246-293`, `backend/engine/tasks.py:159-168`,
   `backend/runs/services/lifecycle.py:152-181`,
   `backend/updates/builders/route/vehicle_positions.py:120-135`)
+
+## Route vehicle positions by route and direction
+
+> Status: `implemented`. The
+> `route_vehicle_positions_by_direction` projection is registered with a concrete
+> resolver, builder, validator, poll refresh, and lifecycle triggers.
+> (`backend/updates/registry.py:141-163`)
+
+### Topic and segment contract
+
+The projection uses this seven-segment topic:
+
+```text
+<transit_system>.route.vehicle_positions.by_route.<route_id>.by_direction.<direction_id>
+```
+
+For example:
+
+```text
+mbta.route.vehicle_positions.by_route.1.by_direction.0
+```
+
+| Segment | Value example | Route-and-direction vehicle-position meaning |
+| --- | --- | --- |
+| Transit system | `mbta` | Uses `TransitSystem.code` and scopes both PostgreSQL runs and Redis state to one transit system. (`backend/feed/models.py:34-43`, `backend/updates/builders/route/vehicle_positions.py:80-90`, `backend/updates/builders/route/vehicle_positions.py:101-108`) |
+| Entity | `route` | Selects the route-level aggregate view. (`backend/updates/registry.py:147-152`) |
+| Information | `vehicle_positions` | Selects current GTFS Realtime vehicle positions. (`backend/updates/registry.py:147-152`) |
+| Primary selector | `by_route` | Interprets the primary value as a GTFS route ID. (`backend/updates/registry.py:147-152`) |
+| Primary value | `1` | Filters `Run` rows to the requested `route_id`. (`backend/updates/builders/route/vehicle_positions.py:80-90`) |
+| Qualifier selector | `by_direction` | Interprets the qualifier value as a canonical GTFS direction ID. (`backend/updates/registry.py:147-152`, `backend/updates/directions.py:6-17`) |
+| Qualifier value | `0` | Adds the selected canonical direction to the `Run` query and the payload wrapper. (`backend/updates/builders/route/vehicle_positions.py:233-245`) |
+
+### Direction qualifier
+
+Only the exact canonical topic values `0` and `1` are accepted. The textual value
+`01` is rejected rather than normalized because the shared mapping contains only
+the keys `"0"` and `"1"`, and lookup rejects every other qualifier value.
+(`backend/updates/directions.py:6-17`)
+
+The projection validator rejects an empty `route_id` before it validates the
+direction. WebSocket subscription handling invokes that validator before joining
+the Channels group and before registering the subscription in Redis.
+(`backend/updates/projections/route/vehicle_positions.py:41-45`,
+`backend/updates/consumers.py:84-90`)
+
+The canonical mapping and `direction_id_from_topic()` helper live in
+`updates/directions.py`. Both the route vehicle-position projection and the stop
+stop-time projection import the same helper instead of defining local direction
+rules. (`backend/updates/directions.py:1-17`,
+`backend/updates/projections/route/vehicle_positions.py:1-6`,
+`backend/updates/projections/stop/stop_time_updates.py:1-8`)
+
+### Run resolution and snapshot construction
+
+The builder obtains the canonical direction from the topic. It then queries
+PostgreSQL for active `Run` rows matching the topic's route and transit system and
+adds `direction_id=<canonical direction>` to the query filters. The active states
+are `In Progress` and `No Signal`.
+(`backend/updates/builders/route/vehicle_positions.py:78-91`,
+`backend/updates/builders/route/vehicle_positions.py:233-239`,
+`backend/runs/services/lifecycle.py:29-32`)
+
+Those PostgreSQL candidates are intersected with the canonical
+`<transit_system>:runs:active` Redis set through `SMISMEMBER`. Exactly one
+non-transactional Redis pipeline reads that membership result, every position
+hash, and the ordered scalar state keys for the snapshot.
+(`backend/updates/builders/route/vehicle_positions.py:94-116`)
+
+The builder excludes a candidate that is absent from the canonical active set or
+lacks a parseable latitude or longitude. It also excludes a candidate whose
+timestamp is older than the configured freshness cutoff; a missing timestamp does
+not exclude the candidate. (`backend/updates/builders/route/vehicle_positions.py:117-163`)
+
+Surviving vehicle snapshots are sorted by textual `run_id`. The qualified wrapper
+then includes the rendered seven-segment topic, route, canonical direction, and
+complete vehicle list. (`backend/updates/builders/route/vehicle_positions.py:165-219`,
+`backend/updates/builders/route/vehicle_positions.py:233-245`)
+
+### Invalidation paths
+
+Vehicle-position snapshots have two invalidation paths:
+
+1. **VehiclePositions poll refresh.** After successful publisher polls record
+   current vehicle state, each affected transit system is refreshed once. The
+   vehicle refresh now selects the two projection names `route_vehicle_positions`
+   and `route_vehicle_positions_by_direction`, then validates, builds, and
+   dispatches each active subscribed topic independently.
+   (`backend/engine/tasks.py:101-120`, `backend/updates/refresh.py:21-70`,
+   `backend/updates/refresh.py:82-90`)
+2. **Run lifecycle invalidation.** The five triggers are signal loss, signal
+   restoration, completion, interruption, and cancellation. The qualified
+   resolver loads the run's route and direction within the event's transit system,
+   discards a row without a nonempty route or canonical direction, and otherwise
+   resolves the corresponding seven-segment topic for the normal event planner.
+   (`backend/updates/registry.py:153-162`,
+   `backend/updates/projections/route/vehicle_positions.py:48-79`,
+   `backend/updates/planner.py:8-14`)
+
+### Payload contract
+
+The builder-produced payload wrapper has exactly four keys: `topic`, `route_id`,
+`direction_id`, and `vehicles`. The wrapper direction uses the `DirectionID` alias,
+and extra wrapper fields are forbidden.
+(`backend/updates/schemas.py:7`, `backend/updates/schemas.py:86-94`,
+`backend/updates/builders/route/vehicle_positions.py:240-245`)
+
+Each vehicle contains `run_id`, `trip_id`, `route_id`, `direction_id`, `latitude`,
+`longitude`, `bearing`, `speed`, `odometer`, `current_stop_sequence`, `stop_id`,
+`current_status`, `congestion_level`, `occupancy_status`, `occupancy_percentage`,
+and `timestamp`. (`backend/updates/schemas.py:53-73`)
+
+### Relationship to the unqualified topic
+
+The five-segment and seven-segment topics coexist as separate registered
+projections. Exact qualifier-selector matching keeps their patterns disjoint, and
+a client chooses either topic by the string supplied in its subscription request.
+(`backend/updates/registry.py:119-163`, `backend/updates/topics.py:81-88`,
+`backend/updates/consumers.py:69-90`)
+
+The unqualified builder applies no direction filter, while the qualified builder
+uses the canonical topic direction in its PostgreSQL query. Consequently, an
+otherwise eligible run whose `direction_id` is `NULL` can appear only in the
+unqualified topic. (`backend/updates/builders/route/vehicle_positions.py:78-91`,
+`backend/updates/builders/route/vehicle_positions.py:222-245`)
+
+### Limitations
+
+- **Runs without direction — `not included`.** A run whose
+  `direction_id` is `NULL` is excluded by the qualified builder's PostgreSQL
+  `direction_id=<canonical direction>` predicate. Snapshot assembly has no
+  redundant direction guard after that query.
+  (`backend/updates/builders/route/vehicle_positions.py:78-91`,
+  `backend/updates/builders/route/vehicle_positions.py:121-219`,
+  `backend/updates/builders/route/vehicle_positions.py:233-245`)
+- **Dual subscriptions — `duplicated construction`.**
+  Subscribing to both topic variants causes two independent snapshot builds in
+  each poll refresh cycle while both topics remain active. The refresh collects
+  each concrete topic separately and invokes its registered builder inside the
+  per-topic loop. (`backend/updates/refresh.py:27-60`,
+  `backend/updates/refresh.py:82-90`,
+  `backend/updates/builders/route/vehicle_positions.py:222-245`)
 
 

--- a/backend/updates/builders/route/vehicle_positions.py
+++ b/backend/updates/builders/route/vehicle_positions.py
@@ -7,7 +7,13 @@ from redis import Redis
 from runs.models import Run
 from runs.services.lifecycle import ACTIVE_STATES, active_runs_key
 
-from updates.schemas import VehiclePositionSnapshot, VehiclePositionsByRouteSnapshot
+from updates.directions import direction_id_from_topic
+from updates.schemas import (
+    DirectionID,
+    VehiclePositionSnapshot,
+    VehiclePositionsByRouteAndDirectionSnapshot,
+    VehiclePositionsByRouteSnapshot,
+)
 from updates.topics import TopicKey
 
 
@@ -69,24 +75,28 @@ def _run_id_sort_key(vehicle: VehiclePositionSnapshot) -> str:
     return str(vehicle.run_id)
 
 
-def build_route_vehicle_positions(topic: TopicKey) -> dict[str, object]:
-    """Build the current vehicle-position snapshot for one route."""
-    route_id: str = topic.primary_value
-    runs: list[Run] = list(
-        Run.objects.filter(
-            route_id=route_id,
-            feed_publisher__transit_system__code=topic.transit_system,
-            run_lifecycle_state__in=ACTIVE_STATES,
-        )
+def _active_runs(topic: TopicKey, direction_id: DirectionID | None) -> list[Run]:
+    """Return the active runs backing one route or route-and-direction snapshot."""
+    filters: dict[str, object] = {
+        "route_id": topic.primary_value,
+        "feed_publisher__transit_system__code": topic.transit_system,
+        "run_lifecycle_state__in": ACTIVE_STATES,
+    }
+    if direction_id is not None:
+        filters["direction_id"] = direction_id
+    return list(
+        Run.objects.filter(**filters)
         .only("id", "trip_id", "route_id", "direction_id")
         .order_by("id")
     )
+
+
+def _build_vehicle_snapshots(
+    topic: TopicKey, runs: list[Run]
+) -> list[VehiclePositionSnapshot]:
+    """Read Redis state once and assemble the ordered vehicle snapshots."""
     if not runs:
-        return VehiclePositionsByRouteSnapshot(
-            topic=topic.render(),
-            route_id=route_id,
-            vehicles=[],
-        ).model_dump(mode="json")
+        return []
 
     run_ids: list[str] = [str(run.id) for run in runs]
     with r.pipeline(transaction=False) as pipe:
@@ -206,8 +216,30 @@ def build_route_vehicle_positions(topic: TopicKey) -> dict[str, object]:
         )
 
     vehicles.sort(key=_run_id_sort_key)
+    return vehicles
+
+
+def build_route_vehicle_positions(topic: TopicKey) -> dict[str, object]:
+    """Build the current vehicle-position snapshot for one route."""
+    runs: list[Run] = _active_runs(topic, None)
+    vehicles: list[VehiclePositionSnapshot] = _build_vehicle_snapshots(topic, runs)
     return VehiclePositionsByRouteSnapshot(
         topic=topic.render(),
-        route_id=route_id,
+        route_id=topic.primary_value,
+        vehicles=vehicles,
+    ).model_dump(mode="json")
+
+
+def build_route_vehicle_positions_by_direction(
+    topic: TopicKey,
+) -> dict[str, object]:
+    """Build the current vehicle-position snapshot for one route and direction."""
+    direction_id: DirectionID = direction_id_from_topic(topic)
+    runs: list[Run] = _active_runs(topic, direction_id)
+    vehicles: list[VehiclePositionSnapshot] = _build_vehicle_snapshots(topic, runs)
+    return VehiclePositionsByRouteAndDirectionSnapshot(
+        topic=topic.render(),
+        route_id=topic.primary_value,
+        direction_id=direction_id,
         vehicles=vehicles,
     ).model_dump(mode="json")

--- a/backend/updates/builders/stop/stop_time_updates.py
+++ b/backend/updates/builders/stop/stop_time_updates.py
@@ -10,7 +10,7 @@ from runs.models import Run
 from runs.services.lifecycle import active_runs_key
 from runs.services.stop_index import approaching_run_ids, run_is_approaching_stop
 
-from updates.projections.stop.stop_time_updates import direction_id_from_topic
+from updates.directions import direction_id_from_topic
 from updates.schemas import (
     DirectionID,
     StopTimeEventSnapshot,

--- a/backend/updates/directions.py
+++ b/backend/updates/directions.py
@@ -1,0 +1,17 @@
+from .exceptions import InvalidTopicException
+from .schemas import DirectionID
+from .topics import TopicKey
+
+
+VALID_DIRECTION_IDS: dict[str, DirectionID] = {"0": 0, "1": 1}
+
+
+def direction_id_from_topic(topic: TopicKey) -> DirectionID:
+    """Return a canonical GTFS direction ID or reject the concrete topic."""
+    value = topic.qualifier_value
+    if value not in VALID_DIRECTION_IDS:
+        raise InvalidTopicException(
+            topic.render(),
+            "direction_id must be the canonical GTFS value 0 or 1.",
+        )
+    return VALID_DIRECTION_IDS[value]

--- a/backend/updates/projections/route/vehicle_positions.py
+++ b/backend/updates/projections/route/vehicle_positions.py
@@ -1,6 +1,7 @@
 from runs.events.types import RunLifecycleEvent
 from runs.models import Run
 
+from updates.directions import direction_id_from_topic
 from updates.exceptions import InvalidTopicException
 from updates.topics import TopicKey
 
@@ -33,5 +34,46 @@ def resolve_vehicle_positions_topics(
             info="vehicle_positions",
             primary_selector="by_route",
             primary_value=str(route_id),
+        )
+    ]
+
+
+def validate_vehicle_positions_by_direction_topic(topic: TopicKey) -> None:
+    """Validate the route ID and direction required by the qualified projection."""
+    if not topic.primary_value:
+        raise InvalidTopicException(topic.render(), "route_id cannot be empty.")
+    direction_id_from_topic(topic)
+
+
+def resolve_vehicle_positions_by_direction_topics(
+    event: RunLifecycleEvent,
+) -> list[TopicKey]:
+    """Resolve a lifecycle invalidation to the run's route-and-direction topic."""
+    row = (
+        Run.objects.filter(
+            id=event.run_id,
+            feed_publisher__transit_system__code=event.transit_system,
+        )
+        .values_list("route_id", "direction_id")
+        .first()
+    )
+    if row is None:
+        return []
+
+    route_id, direction_id = row
+    if route_id is None or route_id == "":
+        return []
+    if direction_id not in (0, 1):
+        return []
+
+    return [
+        TopicKey(
+            transit_system=event.transit_system,
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            primary_value=str(route_id),
+            qualifier_selector="by_direction",
+            qualifier_value=str(direction_id),
         )
     ]

--- a/backend/updates/projections/stop/stop_time_updates.py
+++ b/backend/updates/projections/stop/stop_time_updates.py
@@ -3,23 +3,9 @@ import json
 from runs.events.types import RunLifecycleEvent
 from runs.models import Run
 
+from updates.directions import direction_id_from_topic
 from updates.exceptions import InvalidTopicException
-from updates.schemas import DirectionID
 from updates.topics import TopicKey
-
-
-VALID_DIRECTION_IDS: dict[str, DirectionID] = {"0": 0, "1": 1}
-
-
-def direction_id_from_topic(topic: TopicKey) -> DirectionID:
-    """Return a canonical GTFS direction ID or reject the concrete topic."""
-    value = topic.qualifier_value
-    if value not in VALID_DIRECTION_IDS:
-        raise InvalidTopicException(
-            topic.render(),
-            "direction_id must be the canonical GTFS value 0 or 1.",
-        )
-    return VALID_DIRECTION_IDS[value]
 
 
 def validate_stop_time_updates_topic(topic: TopicKey) -> None:

--- a/backend/updates/refresh.py
+++ b/backend/updates/refresh.py
@@ -20,7 +20,7 @@ r = Redis(
 
 def _refresh_active_topics(
     transit_system: str,
-    projection_name: str,
+    projection_names: frozenset[str],
     log_label: str,
 ) -> int:
     """Rebuild and dispatch active topics for a projection after a successful poll."""
@@ -38,7 +38,7 @@ def _refresh_active_topics(
             continue
 
         projection = projection_for_topic(topic)
-        if projection is None or projection.name != projection_name:
+        if projection is None or projection.name not in projection_names:
             continue
         if not has_subscribers(r, raw_topic):
             continue
@@ -48,7 +48,7 @@ def _refresh_active_topics(
     for topic in sorted(topics, key=TopicKey.render):
         try:
             projection = projection_for_topic(topic)
-            if projection is None or projection.name != projection_name:
+            if projection is None or projection.name not in projection_names:
                 continue
             if not has_subscribers(r, topic.render()):
                 continue
@@ -74,7 +74,7 @@ def refresh_active_stop_time_update_topics(transit_system: str) -> int:
     """Rebuild and dispatch active stop-time topics after a successful poll."""
     return _refresh_active_topics(
         transit_system,
-        "stop_stop_time_updates",
+        frozenset({"stop_stop_time_updates"}),
         "stop-time-update",
     )
 
@@ -83,6 +83,8 @@ def refresh_active_vehicle_position_topics(transit_system: str) -> int:
     """Rebuild and dispatch active route vehicle-position topics after a poll."""
     return _refresh_active_topics(
         transit_system,
-        "route_vehicle_positions",
+        frozenset(
+            {"route_vehicle_positions", "route_vehicle_positions_by_direction"}
+        ),
         "route-vehicle-position",
     )

--- a/backend/updates/registry.py
+++ b/backend/updates/registry.py
@@ -12,13 +12,18 @@ from runs.events.types import (
     RunSignalRestored,
 )
 
-from .builders.route.vehicle_positions import build_route_vehicle_positions
+from .builders.route.vehicle_positions import (
+    build_route_vehicle_positions,
+    build_route_vehicle_positions_by_direction,
+)
 from .builders.stop.occupancy_status import build_stop_occupancy_status
 from .builders.stop.stop_time_updates import build_stop_time_updates
 from .builders.trip.occupancy_status import build_trip_occupancy_status
 from .events import UpdateEvent
 from .projections.route.vehicle_positions import (
+    resolve_vehicle_positions_by_direction_topics,
     resolve_vehicle_positions_topics,
+    validate_vehicle_positions_by_direction_topic,
     validate_vehicle_positions_topic,
 )
 from .projections.stop.occupancy_status import resolve_stop_occupancy_topics
@@ -132,6 +137,29 @@ PROJECTIONS = (
         resolve_topics=resolve_vehicle_positions_topics,
         build=build_route_vehicle_positions,
         validate_topic=validate_vehicle_positions_topic,
+    ),
+    ProjectionSpec(
+        name="route_vehicle_positions_by_direction",
+        description=(
+            "The current vehicle positions for active runs on a route, "
+            "by route ID and direction ID."
+        ),
+        topic_pattern=TopicPattern(
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            qualifier_selector="by_direction",
+        ),
+        triggers=(
+            RunSignalLost,
+            RunSignalRestored,
+            RunCompleted,
+            RunInterrupted,
+            RunCancelled,
+        ),
+        resolve_topics=resolve_vehicle_positions_by_direction_topics,
+        build=build_route_vehicle_positions_by_direction,
+        validate_topic=validate_vehicle_positions_by_direction_topic,
     ),
 )
 

--- a/backend/updates/schemas.py
+++ b/backend/updates/schemas.py
@@ -81,3 +81,14 @@ class VehiclePositionsByRouteSnapshot(BaseModel):
     topic: str
     route_id: str
     vehicles: list[VehiclePositionSnapshot]
+
+
+class VehiclePositionsByRouteAndDirectionSnapshot(BaseModel):
+    """Represent all current vehicle positions for one route and direction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    topic: str
+    route_id: str
+    direction_id: DirectionID
+    vehicles: list[VehiclePositionSnapshot]

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -20,7 +20,9 @@ from updates.events import parse_event
 from updates.exceptions import InvalidTopicException
 from updates.planner import process_event
 from updates.projections.route.vehicle_positions import (
+    resolve_vehicle_positions_by_direction_topics,
     resolve_vehicle_positions_topics,
+    validate_vehicle_positions_by_direction_topic,
     validate_vehicle_positions_topic,
 )
 from updates.projections.stop.occupancy_status import (
@@ -1544,6 +1546,120 @@ class RouteVehiclePositionsProjectionTests(SimpleTestCase):
 
         self.assertIn("stop_stop_time_updates", projection_names)
         self.assertIn("route_vehicle_positions", projection_names)
+
+
+class RouteVehiclePositionsByDirectionProjectionTests(SimpleTestCase):
+    def test_qualified_topic_round_trip(self):
+        raw = (
+            "mbta.route.vehicle_positions.by_route."
+            "route-a.by_direction.0"
+        )
+
+        topic = TopicKey.parse(raw)
+
+        self.assertEqual(topic.render(), raw)
+        self.assertEqual(topic.qualifier_selector, "by_direction")
+        self.assertEqual(topic.qualifier_value, "0")
+
+    def test_registry_resolves_qualified_topic_to_its_own_projection(self):
+        projection = projection_for_topic(
+            TopicKey.parse(
+                "mbta.route.vehicle_positions.by_route."
+                "route-a.by_direction.0"
+            )
+        )
+
+        self.assertIsNotNone(projection)
+        self.assertEqual(
+            projection.name,
+            "route_vehicle_positions_by_direction",
+        )
+
+    def test_registry_still_resolves_unqualified_topic_to_the_original_projection(
+        self,
+    ):
+        projection = projection_for_topic(
+            TopicKey.parse("mbta.route.vehicle_positions.by_route.route-a")
+        )
+
+        self.assertIsNotNone(projection)
+        self.assertEqual(projection.name, "route_vehicle_positions")
+
+    def test_validator_rejects_empty_route_id(self):
+        topic = TopicKey(
+            transit_system="mbta",
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            primary_value="",
+            qualifier_selector="by_direction",
+            qualifier_value="0",
+        )
+
+        with self.assertRaises(InvalidTopicException):
+            validate_vehicle_positions_by_direction_topic(topic)
+
+    def test_validator_rejects_noncanonical_direction(self):
+        topic = TopicKey(
+            transit_system="mbta",
+            entity="route",
+            info="vehicle_positions",
+            primary_selector="by_route",
+            primary_value="route-a",
+            qualifier_selector="by_direction",
+            qualifier_value="01",
+        )
+
+        with self.assertRaises(InvalidTopicException):
+            validate_vehicle_positions_by_direction_topic(topic)
+
+    @patch("updates.projections.route.vehicle_positions.Run.objects.filter")
+    def test_lifecycle_resolver_returns_qualified_topic(self, filter_runs):
+        filter_runs.return_value.values_list.return_value.first.return_value = (
+            "route-a",
+            0,
+        )
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        topics = resolve_vehicle_positions_by_direction_topics(event)
+
+        self.assertEqual(
+            [topic.render() for topic in topics],
+            [
+                "mbta.route.vehicle_positions.by_route."
+                "route-a.by_direction.0"
+            ],
+        )
+        filter_runs.assert_called_once_with(
+            id=event.run_id,
+            feed_publisher__transit_system__code="mbta",
+        )
+
+    @patch("updates.projections.route.vehicle_positions.Run.objects.filter")
+    def test_lifecycle_resolver_returns_empty_for_run_without_direction(
+        self,
+        filter_runs,
+    ):
+        filter_runs.return_value.values_list.return_value.first.return_value = (
+            "route-a",
+            None,
+        )
+        event = RunCompleted(
+            transit_system="mbta",
+            run_id=uuid4(),
+            reason="Reached terminal.",
+            occurred_at="2026-08-02T12:00:00Z",
+        )
+
+        self.assertEqual(
+            resolve_vehicle_positions_by_direction_topics(event),
+            [],
+        )
 
 
 class ActiveTopicRefreshTests(SimpleTestCase):

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -1900,3 +1900,152 @@ class ActiveTopicRefreshTests(SimpleTestCase):
             TopicKey.parse(healthy),
             {"vehicles": []},
         )
+
+
+class QualifiedVehiclePositionRefreshTests(SimpleTestCase):
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_dispatches_the_qualified_topic(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        qualified = (
+            "mbta.route.vehicle_positions.by_route.route-a.by_direction.1"
+        )
+        active_topics.return_value = {qualified}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions_by_direction",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 1)
+        projection.build.assert_called_once_with(TopicKey.parse(qualified))
+        dispatch.assert_called_once_with(
+            TopicKey.parse(qualified),
+            {"vehicles": []},
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_vehicle_refresh_dispatches_both_variants_together(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        unqualified = "mbta.route.vehicle_positions.by_route.route-a"
+        qualified = (
+            "mbta.route.vehicle_positions.by_route.route-a.by_direction.1"
+        )
+        active_topics.return_value = {unqualified, qualified}
+        unqualified_projection = SimpleNamespace(
+            name="route_vehicle_positions",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        qualified_projection = SimpleNamespace(
+            name="route_vehicle_positions_by_direction",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.side_effect = lambda topic: (
+            qualified_projection
+            if topic.render() == qualified
+            else unqualified_projection
+        )
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 2)
+        unqualified_projection.build.assert_called_once_with(
+            TopicKey.parse(unqualified)
+        )
+        qualified_projection.build.assert_called_once_with(TopicKey.parse(qualified))
+        self.assertEqual(dispatch.call_count, 2)
+        dispatch.assert_has_calls(
+            [
+                call(TopicKey.parse(unqualified), {"vehicles": []}),
+                call(TopicKey.parse(qualified), {"vehicles": []}),
+            ],
+            any_order=True,
+        )
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_stop_time_refresh_ignores_the_qualified_vehicle_topic(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_stop_time_update_topics
+
+        qualified = (
+            "mbta.route.vehicle_positions.by_route.route-a.by_direction.1"
+        )
+        active_topics.return_value = {qualified}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions_by_direction",
+            validate_topic=Mock(),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_stop_time_update_topics("mbta")
+
+        self.assertEqual(count, 0)
+        projection.validate_topic.assert_not_called()
+        projection.build.assert_not_called()
+        dispatch.assert_not_called()
+
+    @patch("updates.refresh.dispatch")
+    @patch("updates.refresh.projection_for_topic")
+    @patch("updates.refresh.has_subscribers", return_value=True)
+    @patch("updates.refresh.active_subscription_topics")
+    def test_qualified_topic_validator_runs_before_build(
+        self,
+        active_topics,
+        _has_subscribers,
+        projection_for_topic_mock,
+        dispatch,
+    ):
+        from updates.refresh import refresh_active_vehicle_position_topics
+
+        qualified = (
+            "mbta.route.vehicle_positions.by_route.route-a.by_direction.1"
+        )
+        active_topics.return_value = {qualified}
+        projection = SimpleNamespace(
+            name="route_vehicle_positions_by_direction",
+            validate_topic=Mock(
+                side_effect=InvalidTopicException(qualified, "Rejected direction.")
+            ),
+            build=Mock(return_value={"vehicles": []}),
+        )
+        projection_for_topic_mock.return_value = projection
+
+        count = refresh_active_vehicle_position_topics("mbta")
+
+        self.assertEqual(count, 0)
+        projection.validate_topic.assert_called_once_with(TopicKey.parse(qualified))
+        projection.build.assert_not_called()
+        dispatch.assert_not_called()

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -10,7 +10,10 @@ from pydantic import ValidationError
 
 from runs.events.types import OccupancyStatusChanged
 from runs.events.types import RunCompleted
-from updates.builders.route.vehicle_positions import build_route_vehicle_positions
+from updates.builders.route.vehicle_positions import (
+    build_route_vehicle_positions,
+    build_route_vehicle_positions_by_direction,
+)
 from updates.builders.stop.stop_time_updates import build_stop_time_updates
 from updates.consumers import UpdatesConsumer
 from updates.events import parse_event
@@ -891,7 +894,7 @@ class VehiclePositionSchemaTests(SimpleTestCase):
         self,
     ):
         snapshot = VehiclePositionsByRouteAndDirectionSnapshot(
-            topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.0",
+            topic="mbta.route.vehicle_positions.by_route.route-a.by_direction.0",
             route_id="route-a",
             direction_id=0,
             vehicles=[],
@@ -905,7 +908,7 @@ class VehiclePositionSchemaTests(SimpleTestCase):
     ):
         with self.assertRaises(ValidationError):
             VehiclePositionsByRouteAndDirectionSnapshot(
-                topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.2",
+                topic="mbta.route.vehicle_positions.by_route.route-a.by_direction.2",
                 route_id="route-a",
                 direction_id=2,
                 vehicles=[],
@@ -914,7 +917,7 @@ class VehiclePositionSchemaTests(SimpleTestCase):
     def test_vehicle_positions_by_route_and_direction_snapshot_rejects_unknown_field(self):
         with self.assertRaises(ValidationError):
             VehiclePositionsByRouteAndDirectionSnapshot(
-                topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.0",
+                topic="mbta.route.vehicle_positions.by_route.route-a.by_direction.0",
                 route_id="route-a",
                 direction_id=0,
                 vehicles=[],
@@ -1302,6 +1305,121 @@ class RouteVehiclePositionsBuilderTests(SimpleTestCase):
             )
 
         snapshot_model.assert_not_called()
+
+
+@override_settings(GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS=120)
+class RouteVehiclePositionsByDirectionBuilderTests(SimpleTestCase):
+    now_timestamp: int = 1_800_000_000
+
+    def _run(
+        self,
+        *,
+        run_id: UUID | None = None,
+        route_id: str = "route-a",
+        transit_system: str = "mbta",
+        trip_id: str | None = "trip-a",
+        direction_id: int | None = 1,
+        lifecycle_state: str = "In Progress",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=run_id or uuid4(),
+            trip_id=trip_id,
+            route_id=route_id,
+            direction_id=direction_id,
+            run_lifecycle_state=lifecycle_state,
+            feed_publisher=SimpleNamespace(
+                transit_system=SimpleNamespace(code=transit_system)
+            ),
+        )
+
+    def _snapshot(
+        self,
+        runs: list[SimpleNamespace],
+        positions: dict[str, dict[str, str]],
+        *,
+        direction_id: str = "0",
+    ) -> tuple[dict[str, Any], Mock, Mock, Mock, TopicKey]:
+        run_ids = [str(run.id) for run in runs]
+
+        with (
+            patch("updates.builders.route.vehicle_positions.r") as redis,
+            patch(
+                "updates.builders.route.vehicle_positions.Run.objects.filter"
+            ) as filter_runs,
+            patch(
+                "updates.builders.route.vehicle_positions.timezone.now",
+                return_value=datetime.fromtimestamp(self.now_timestamp, tz=UTC),
+            ),
+        ):
+            filter_runs.return_value.only.return_value.order_by.return_value = runs
+            pipeline = redis.pipeline.return_value.__enter__.return_value
+            pipeline.execute.return_value = [
+                [True for _run_id in run_ids],
+                *[positions.get(run_id, {}) for run_id in run_ids],
+                *[[None] * 7 for _run_id in run_ids],
+            ]
+            topic = TopicKey.parse(
+                "mbta.route.vehicle_positions.by_route."
+                f"route-a.by_direction.{direction_id}"
+            )
+            snapshot = build_route_vehicle_positions_by_direction(topic)
+        return snapshot, redis, filter_runs, pipeline, topic
+
+    def test_returns_empty_snapshot_when_route_and_direction_have_no_active_runs(self):
+        snapshot, redis, _filter_runs, _pipeline, _topic = self._snapshot([], {})
+
+        self.assertEqual(snapshot["vehicles"], [])
+        self.assertEqual(
+            snapshot["topic"],
+            "mbta.route.vehicle_positions.by_route.route-a.by_direction.0",
+        )
+        self.assertEqual(snapshot["route_id"], "route-a")
+        self.assertEqual(snapshot["direction_id"], 0)
+        redis.pipeline.assert_not_called()
+
+    def test_passes_direction_to_the_run_query(self):
+        _snapshot, _redis, filter_runs, _pipeline, _topic = self._snapshot([], {})
+
+        filter_runs.assert_called_once_with(
+            route_id="route-a",
+            feed_publisher__transit_system__code="mbta",
+            run_lifecycle_state__in={"In Progress", "No Signal"},
+            direction_id=0,
+        )
+
+    def test_excludes_runs_in_the_other_direction(self):
+        matching = self._run(direction_id=0)
+        other = self._run(direction_id=1)
+        positions = {
+            str(run.id): {"latitude": "9.93", "longitude": "-84.08"}
+            for run in (matching, other)
+        }
+
+        snapshot, _redis, _filter_runs, _pipeline, _topic = self._snapshot(
+            [matching],
+            positions,
+        )
+
+        self.assertEqual(
+            [vehicle["run_id"] for vehicle in snapshot["vehicles"]],
+            [str(matching.id)],
+        )
+
+    def test_snapshot_envelope_carries_topic_and_direction(self):
+        snapshot, _redis, _filter_runs, _pipeline, topic = self._snapshot([], {})
+
+        self.assertEqual(
+            set(snapshot),
+            {"topic", "route_id", "direction_id", "vehicles"},
+        )
+        self.assertEqual(snapshot["topic"], topic.render())
+        self.assertEqual(snapshot["route_id"], "route-a")
+        self.assertEqual(snapshot["direction_id"], 0)
+        self.assertEqual(snapshot["vehicles"], [])
+
+    def test_rejects_noncanonical_direction_in_topic(self):
+        with self.assertRaises(InvalidTopicException):
+            self._snapshot([], {}, direction_id="2")
 
 
 class RouteVehiclePositionsProjectionTests(SimpleTestCase):

--- a/backend/updates/tests.py
+++ b/backend/updates/tests.py
@@ -31,7 +31,11 @@ from updates.projections.trip.occupancy_status import (
     resolve_trip_occupancy_topics,
 )
 from updates.registry import projection_for_topic, projections_for_event
-from updates.schemas import VehiclePositionSnapshot, VehiclePositionsByRouteSnapshot
+from updates.schemas import (
+    VehiclePositionSnapshot,
+    VehiclePositionsByRouteAndDirectionSnapshot,
+    VehiclePositionsByRouteSnapshot,
+)
 from updates.topics import TopicKey
 
 
@@ -882,6 +886,40 @@ class VehiclePositionSchemaTests(SimpleTestCase):
         )
 
         self.assertEqual(snapshot.model_dump(mode="json")["vehicles"], [])
+
+    def test_vehicle_positions_by_route_and_direction_snapshot_accepts_empty_vehicle_list(
+        self,
+    ):
+        snapshot = VehiclePositionsByRouteAndDirectionSnapshot(
+            topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.0",
+            route_id="route-a",
+            direction_id=0,
+            vehicles=[],
+        )
+
+        self.assertEqual(snapshot.direction_id, 0)
+        self.assertEqual(snapshot.vehicles, [])
+
+    def test_vehicle_positions_by_route_and_direction_snapshot_rejects_noncanonical_direction(
+        self,
+    ):
+        with self.assertRaises(ValidationError):
+            VehiclePositionsByRouteAndDirectionSnapshot(
+                topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.2",
+                route_id="route-a",
+                direction_id=2,
+                vehicles=[],
+            )
+
+    def test_vehicle_positions_by_route_and_direction_snapshot_rejects_unknown_field(self):
+        with self.assertRaises(ValidationError):
+            VehiclePositionsByRouteAndDirectionSnapshot(
+                topic="mbta.route.vehicle_positions.by_route_and_direction.route-a.0",
+                route_id="route-a",
+                direction_id=0,
+                vehicles=[],
+                unknown_field="unexpected",
+            )
 
 
 @override_settings(GTFS_RT_VEHICLE_POSITION_STALE_TOLERANCE_SECONDS=120)


### PR DESCRIPTION
 ## Summary

  This change adds a public direction-qualified vehicle-position topic for active runs on a route. It coexists with the
  existing five-segment route topic, preserving its contract and behavior. No database schema changes or migrations are
  included.

  ## Topic contract

  The new seven-segment topic is:

  ```text
  <transit_system>.route.vehicle_positions.by_route.<route_id>.by_direction.<direction_id>
  ```

  The first segment is always `TransitSystem.code`; for example:

  ```text
  mbta.route.vehicle_positions.by_route.Red.by_direction.0
  ```

  An abbreviated payload contains the four wrapper keys:

  ```json
  {
    "topic": "mbta.route.vehicle_positions.by_route.Red.by_direction.0",
    "route_id": "Red",
    "direction_id": 0,
    "vehicles": []
  }
  ```

  ## What changed

  - `backend/updates/builders/route/vehicle_positions.py` factors shared run selection and snapshot assembly into
  private helpers and adds the public direction-qualified builder.
  - `backend/updates/builders/stop/stop_time_updates.py` imports the canonical direction parser from the shared
  direction module so both topic families use the same rule.
  - `backend/updates/directions.py` defines the canonical `0|1` mapping and the shared `direction_id_from_topic()`
  helper.
  - `backend/updates/projections/route/vehicle_positions.py` adds validation and lifecycle-topic resolution for the
  qualified route projection.
  - `backend/updates/projections/stop/stop_time_updates.py` removes its local direction implementation and delegates to
  the shared helper.
  - `backend/updates/refresh.py` allows one poll refresh path to select a set of projection names so both route vehicle-
  position variants are refreshed.
  - `backend/updates/registry.py` registers `route_vehicle_positions_by_direction` with its disjoint topic pattern,
  triggers, resolver, builder, and validator.
  - `backend/updates/schemas.py` adds the strict `VehiclePositionsByRouteAndDirectionSnapshot` wrapper schema.
  - `backend/updates/tests.py` adds schema, builder, projection, registry, coexistence, validation, and poll-refresh
  coverage without changing pre-existing test bodies.
  - `backend/updates/README.md` documents the qualified contract and verifies its relationship with the existing
  unqualified topic.

  ## Design decisions

  ### Coexistence over replacement

  The qualified topic is registered alongside the production five-segment topic so existing subscribers retain the
  original aggregate view. The five- and seven-segment patterns are disjoint because `TopicPattern.matches()` compares
  `qualifier_selector` by exact equality, including `None`.

  ### Shared direction canon

  The canonical `0|1` rule lives in `updates/directions.py` so route vehicle positions and stop-time updates share one
  neutral implementation. This avoids duplicating the rule or making the route projection depend on the stop projection.

  ### Direction filter in SQL

  The qualified builder adds `direction_id` to the same keyword-filter mapping used for route, transit system, and
  active lifecycle state, then issues one `.filter()` call. PostgreSQL therefore excludes `NULL` directions through the
  equality predicate without a redundant in-memory guard, while retaining one `.filter()` call for compatibility with
  existing test mocks.

  ### Poll refresh generalization

  `_refresh_active_topics()` now accepts a `frozenset` of projection names so a successful vehicle-position poll
  refreshes both registered route variants. The public refresh signatures remain unchanged, so `backend/engine/tasks.py`
  required no modification.

  ## Testing

  The base contains 63 discoverable tests in `backend/updates/tests.py`: 60 synchronous test methods reported by the
  required `FunctionDef` audit plus three pre-existing asynchronous test methods. The current suite contains 82 tests,
  for a delta of 19 added tests.

  - `updates`: found 82 tests, ran 82 tests, `OK`.
  - `engine`: found 8 tests, ran 8 tests, `OK`.

  No pre-existing test body was modified; the `backend/updates/tests.py` test-case diff is additive, with only the
  import expansion needed by the new cases.

  The qualified topic was also validated end to end against live MBTA feeds and feeds from other transit systems, with
  vehicles separated correctly by direction.

  ## Documentation

  `backend/updates/README.md` received a new direction-qualified vehicle-position section and an additive verification
  note beside the existing unqualified-topic contract. Existing text was not rewritten; the file has 148 insertions and
  0 deletions.

## Notes for review

- The README contains a pre-existing statement that classifies both the route
  vehicle-position projection and builder as empty and unregistered. That statement
  predates this work and was deliberately left out of scope
  (`backend/updates/README.md:1257-1264`, `backend/updates/README.md:1267-1274`).
- The README's "Current implementation status" section lists occupancy and stop-time
  projections but neither the existing nor the new vehicle-position variant
  (`backend/updates/README.md:167-204`).
- The registry uses `stop_stop_time_updates` for the qualified stop projection and
  `route_vehicle_positions_by_direction` for the new qualified route projection,
  preserving a pre-existing naming inconsistency.